### PR TITLE
feat: add manifest and key normalization for storage backends

### DIFF
--- a/.github/ISSUE_TEMPLATE/pr-checklist.yml
+++ b/.github/ISSUE_TEMPLATE/pr-checklist.yml
@@ -1,0 +1,90 @@
+name: PR Checklist - 1.0 Readiness Slice
+description: Actionable checklist for a scoped readiness PR (S/M/L) with acceptance criteria.
+title: "PR Slice: <S1/M1/L1> - <short title>"
+labels:
+  - enhancement
+  - quality
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template to execute one incremental readiness slice with clear scope, validation, and rollback safety.
+  - type: input
+    id: slice_id
+    attributes:
+      label: Slice ID
+      description: Use roadmap IDs like S1, S2, M1, L1.
+      placeholder: S1
+    validations:
+      required: true
+  - type: textarea
+    id: objective
+    attributes:
+      label: Objective
+      description: What this PR changes and why.
+      placeholder: Fix default provider routing and enforce canonical storage key normalization in CLI update path.
+    validations:
+      required: true
+  - type: textarea
+    id: in_scope
+    attributes:
+      label: In Scope
+      description: Explicitly list files/modules that this PR is allowed to modify.
+      value: |
+        - src/ml4t/data/...
+        - tests/...
+    validations:
+      required: true
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out Of Scope
+      description: Prevent scope creep.
+      value: |
+        - No unrelated refactors
+        - No dependency upgrades unless required
+    validations:
+      required: true
+  - type: checkboxes
+    id: implementation_checklist
+    attributes:
+      label: Implementation Checklist
+      options:
+        - label: Add/adjust core logic for this slice
+        - label: Keep behavior backward-compatible or add explicit migration handling
+        - label: Add/adjust tests covering happy path + edge path + regression path
+        - label: Update CLI/API contract where affected
+        - label: Keep changes minimal and focused
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance Criteria
+      description: Measurable completion conditions.
+      value: |
+        - [ ] Targeted tests for modified behavior pass locally
+        - [ ] No regressions in relevant existing tests
+        - [ ] Lint/type checks pass for touched code
+        - [ ] Behavior is deterministic and offline-testable
+    validations:
+      required: true
+  - type: textarea
+    id: validation_plan
+    attributes:
+      label: Validation Plan
+      description: Commands to run before merge.
+      value: |
+        uv run ruff check src/ tests/
+        uv run ty check
+        uv run pytest tests/<target_file_or_subset> -q
+    validations:
+      required: true
+  - type: textarea
+    id: risk_and_rollback
+    attributes:
+      label: Risk and Rollback
+      description: Main risks and rollback strategy if needed.
+      placeholder: |
+        Risk: routing logic changes provider defaults for ambiguous symbols.
+        Rollback: revert router default logic and keep key normalization utility isolated.
+    validations:
+      required: true

--- a/src/ml4t/data/cli/config.py
+++ b/src/ml4t/data/cli/config.py
@@ -140,7 +140,7 @@ def server(host, port, reload):
 
     except ImportError:
         console.print(
-            "[red]API dependencies not installed. Install with: pip install 'ml4t-data[api]'[/red]"
+            "[red]API dependencies not installed. Install with: uv add 'ml4t-data[all-providers]'[/red]"
         )
         raise click.Abort()
     except Exception as e:
@@ -150,7 +150,8 @@ def server(host, port, reload):
 
 @click.command("show-completion")
 @click.argument("shell", type=click.Choice(["bash", "zsh", "fish"]))
-def show_completion(shell):
+@click.pass_context
+def show_completion(ctx, shell):
     """Show shell completion script.
 
     To enable completion:
@@ -164,17 +165,13 @@ def show_completion(shell):
     Fish:
         eval (env _ML4T_DATA_COMPLETE=fish_source ml4t-data)
     """
-    import os
-    import subprocess
+    from click.shell_completion import get_completion_class
 
-    env = os.environ.copy()
-    env["_QDATA_COMPLETE"] = f"{shell}_source"
+    completion_class = get_completion_class(shell)
+    if completion_class is None:
+        raise click.Abort()
 
-    result = subprocess.run(
-        [sys.executable, "-m", "mlquant.data.cli_interface"],
-        env=env,
-        capture_output=True,
-        text=True,
-    )
-
-    console.print(result.stdout)
+    root_command = ctx.find_root().command
+    complete_var = "_ML4T_DATA_COMPLETE"
+    completion = completion_class(root_command, {}, "ml4t-data", complete_var)
+    console.print(completion.source())

--- a/src/ml4t/data/cli/core.py
+++ b/src/ml4t/data/cli/core.py
@@ -15,9 +15,12 @@ from rich import box
 from rich.panel import Panel
 from rich.table import Table
 
+from ml4t.data.core.keys import is_storage_key, normalize_storage_key, parse_storage_key
 from ml4t.data.data_manager import DataManager
 from ml4t.data.storage.backend import StorageConfig
 from ml4t.data.storage.hive import HiveStorage
+from ml4t.data.storage.key_codec import decode_storage_key
+from ml4t.data.storage.manifest import normalize_manifest_payload
 from ml4t.data.storage.metadata_tracker import MetadataTracker
 from ml4t.data.update_manager import IncrementalUpdater, UpdateStrategy
 
@@ -156,8 +159,15 @@ def fetch(ctx, symbol, symbols_file, start, end, frequency, provider, output, co
 )
 @click.option("--provider", "-p", help="Provider to use for fetching")
 @click.option("--storage-path", default="./data", help="Storage directory path")
+@click.option("--asset-class", default="equities", help="Asset class for storage key")
+@click.option(
+    "--frequency",
+    default="daily",
+    type=click.Choice(["daily", "hourly", "weekly"]),
+    help="Data frequency for storage key and fetching",
+)
 @click.pass_context
-def update(ctx, symbol, start, end, strategy, provider, storage_path):
+def update(ctx, symbol, start, end, strategy, provider, storage_path, asset_class, frequency):
     """Perform incremental data updates."""
     verbose = ctx.obj.get("verbose", False)
     quiet = ctx.obj.get("quiet", False)
@@ -169,6 +179,12 @@ def update(ctx, symbol, start, end, strategy, provider, storage_path):
 
         update_strategy = UpdateStrategy[strategy.upper()]
         updater = IncrementalUpdater(strategy=update_strategy)
+        storage_key = normalize_storage_key(
+            symbol_or_key=symbol,
+            asset_class=asset_class,
+            frequency=frequency,
+        )
+        fetch_symbol = parse_storage_key(storage_key)[2] if is_storage_key(symbol) else symbol
 
         if not end:
             end = datetime.now().strftime("%Y-%m-%d")
@@ -177,14 +193,14 @@ def update(ctx, symbol, start, end, strategy, provider, storage_path):
 
         actual_start, actual_end, update_type = updater.determine_update_range(
             storage,
-            symbol,
+            storage_key,
             datetime.strptime(start, "%Y-%m-%d"),
             datetime.strptime(end, "%Y-%m-%d"),
         )
 
         if update_type == "none":
             if not quiet:
-                print_success(f"Data already up to date for {symbol}")
+                print_success(f"Data already up to date for {fetch_symbol}")
             return
 
         if not quiet:
@@ -195,9 +211,10 @@ def update(ctx, symbol, start, end, strategy, provider, storage_path):
 
         dm = DataManager()
         new_data = dm.fetch(
-            symbol,
+            fetch_symbol,
             actual_start.strftime("%Y-%m-%d"),
             actual_end.strftime("%Y-%m-%d"),
+            frequency=frequency,
             provider=provider,
         )
 
@@ -209,7 +226,7 @@ def update(ctx, symbol, start, end, strategy, provider, storage_path):
         result = updater.update_incremental(
             storage,
             tracker,
-            symbol,
+            storage_key,
             new_data,
             provider=provider or "auto",
             strategy=update_strategy,
@@ -326,11 +343,20 @@ def validate(ctx, symbol, validate_all, anomalies, save_report, severity, storag
                         ReturnOutlierDetector,
                         VolumeSpikeDetector,
                     )
+                    from ml4t.data.anomaly.config import (
+                        PriceStalenessConfig,
+                        ReturnOutlierConfig,
+                        VolumeSpikeConfig,
+                    )
 
                     manager = AnomalyManager()
-                    manager.detectors.append(PriceStalenessDetector(max_gap_days=3))
-                    manager.detectors.append(ReturnOutlierDetector(threshold=5.0))
-                    manager.detectors.append(VolumeSpikeDetector(threshold=10.0))
+                    manager.detectors.append(
+                        PriceStalenessDetector(PriceStalenessConfig(max_unchanged_days=3))
+                    )
+                    manager.detectors.append(
+                        ReturnOutlierDetector(ReturnOutlierConfig(threshold=5.0))
+                    )
+                    manager.detectors.append(VolumeSpikeDetector(VolumeSpikeConfig(threshold=10.0)))
 
                     report = manager.analyze(df, symbol=sym, asset_class="unknown")
 
@@ -568,18 +594,23 @@ def list_data(_ctx, config, storage_path):
             with open(meta_file) as f:
                 meta = json_module.load(f)
 
-            custom = meta.get("custom", {})
-            provider = custom.get("provider")
-            symbol = custom.get("symbol")
+            decoded_key = decode_storage_key(meta_file.stem)
+            normalized = normalize_manifest_payload(decoded_key, meta)
+            provider = normalized.get("provider")
+            symbol = normalized.get("symbol")
 
             if not symbol or not provider:
                 continue
 
+            data_range = normalized.get("data_range")
+            if not isinstance(data_range, dict):
+                data_range = {}
+
             data_info = {
-                "rows": meta.get("row_count", 0),
-                "start": custom.get("start_date", ""),
-                "end": custom.get("end_date", ""),
-                "updated": custom.get("last_updated", ""),
+                "rows": normalized.get("row_count", normalized.get("total_rows", 0)),
+                "start": data_range.get("start", ""),
+                "end": data_range.get("end", ""),
+                "updated": normalized.get("last_updated", ""),
             }
 
             if provider == "databento":

--- a/src/ml4t/data/core/keys.py
+++ b/src/ml4t/data/core/keys.py
@@ -1,0 +1,61 @@
+"""Storage key helpers.
+
+Canonical storage key format:
+    <asset_class>/<frequency>/<symbol>
+"""
+
+from __future__ import annotations
+
+DEFAULT_ASSET_CLASS = "equities"
+DEFAULT_FREQUENCY = "daily"
+
+
+def is_storage_key(value: str) -> bool:
+    """Return True when value is already a canonical storage key."""
+    parts = value.split("/")
+    return len(parts) == 3 and all(part.strip() for part in parts)
+
+
+def build_storage_key(
+    symbol: str,
+    asset_class: str = DEFAULT_ASSET_CLASS,
+    frequency: str = DEFAULT_FREQUENCY,
+) -> str:
+    """Build canonical storage key from parts."""
+    symbol_clean = symbol.strip()
+    asset_class_clean = asset_class.strip()
+    frequency_clean = frequency.strip()
+
+    if not symbol_clean:
+        raise ValueError("symbol cannot be empty")
+    if not asset_class_clean:
+        raise ValueError("asset_class cannot be empty")
+    if not frequency_clean:
+        raise ValueError("frequency cannot be empty")
+
+    return f"{asset_class_clean}/{frequency_clean}/{symbol_clean}"
+
+
+def parse_storage_key(key: str) -> tuple[str, str, str]:
+    """Parse canonical key into (asset_class, frequency, symbol)."""
+    if not is_storage_key(key):
+        raise ValueError(f"invalid storage key format: {key}")
+    asset_class, frequency, symbol = key.split("/", 2)
+    return asset_class, frequency, symbol
+
+
+def normalize_storage_key(
+    symbol_or_key: str,
+    asset_class: str = DEFAULT_ASSET_CLASS,
+    frequency: str = DEFAULT_FREQUENCY,
+) -> str:
+    """Normalize symbol or key into canonical storage key format."""
+    value = symbol_or_key.strip()
+    if not value:
+        raise ValueError("symbol_or_key cannot be empty")
+
+    if is_storage_key(value):
+        parsed_asset_class, parsed_frequency, parsed_symbol = parse_storage_key(value)
+        return build_storage_key(parsed_symbol, parsed_asset_class, parsed_frequency)
+
+    return build_storage_key(value, asset_class, frequency)

--- a/src/ml4t/data/macro/downloader.py
+++ b/src/ml4t/data/macro/downloader.py
@@ -251,6 +251,7 @@ class MacroDataManager:
                     end=self.config.end,
                     progress=False,
                     auto_adjust=True,
+                    threads=False,
                 )
 
                 if df.empty:
@@ -281,7 +282,7 @@ class MacroDataManager:
         # Join all series on timestamp
         result = dfs[0]
         for df in dfs[1:]:
-            result = result.join(df, on="timestamp", how="outer_coalesce")
+            result = result.join(df, on="timestamp", how="full", coalesce=True)
 
         return result.sort("timestamp")
 

--- a/src/ml4t/data/managers/metadata_manager.py
+++ b/src/ml4t/data/managers/metadata_manager.py
@@ -14,6 +14,9 @@ from typing import Any
 import polars as pl
 import structlog
 
+from ml4t.data.storage.key_codec import encode_storage_key
+from ml4t.data.storage.manifest import normalize_manifest_payload
+
 logger = structlog.get_logger()
 
 
@@ -119,16 +122,25 @@ class MetadataManager:
         Returns:
             Metadata dict or None if not found
         """
-        if not hasattr(self.storage, "metadata_dir"):
-            return None
-
         try:
-            metadata_file = self.storage.metadata_dir / f"{key.replace('/', '_')}.json"
-            if not metadata_file.exists():
+            if hasattr(self.storage, "get_metadata"):
+                metadata = self.storage.get_metadata(key)
+                if metadata is not None:
+                    return normalize_manifest_payload(key, metadata)
+
+            if not hasattr(self.storage, "metadata_dir"):
                 return None
 
-            with open(metadata_file) as f:
-                return json.load(f)
+            metadata_files = [
+                self.storage.metadata_dir / f"{encode_storage_key(key)}.json",
+                self.storage.metadata_dir / f"{key.replace('/', '_')}.json",
+            ]
+
+            for metadata_file in metadata_files:
+                if metadata_file.exists():
+                    with open(metadata_file) as f:
+                        return normalize_manifest_payload(key, json.load(f))
+            return None
         except Exception as e:
             logger.warning(f"Failed to read metadata for {key}: {e}")
             return None

--- a/src/ml4t/data/storage/async_migration.py
+++ b/src/ml4t/data/storage/async_migration.py
@@ -220,15 +220,21 @@ class AsyncStorageAdapter:
         """
         self.async_backend = async_backend
         self._loop: asyncio.AbstractEventLoop | None = None
+        self._owns_loop = False
 
     def _get_loop(self) -> asyncio.AbstractEventLoop:
         """Get or create event loop."""
         if self._loop is None or self._loop.is_closed():
             try:
-                self._loop = asyncio.get_running_loop()
+                asyncio.get_running_loop()
             except RuntimeError:
                 self._loop = asyncio.new_event_loop()
-                asyncio.set_event_loop(self._loop)
+                self._owns_loop = True
+            else:
+                raise RuntimeError(
+                    "AsyncStorageAdapter sync methods cannot run inside an active event loop; "
+                    "use the async backend directly."
+                )
         return self._loop
 
     def write(self, data):
@@ -255,6 +261,29 @@ class AsyncStorageAdapter:
         """Sync wrapper for async list_keys."""
         loop = self._get_loop()
         return loop.run_until_complete(self.async_backend.list_keys(prefix))
+
+    def close(self) -> None:
+        """Close the private event loop created by this adapter."""
+        if self._owns_loop and self._loop is not None and not self._loop.is_closed():
+            self._loop.close()
+        self._loop = None
+        self._owns_loop = False
+
+    def __enter__(self) -> AsyncStorageAdapter:
+        """Support context manager usage for deterministic loop cleanup."""
+        return self
+
+    def __exit__(self, _exc_type, _exc_value, _traceback) -> bool:
+        """Close owned loop on context exit."""
+        self.close()
+        return False
+
+    def __del__(self) -> None:
+        """Best-effort cleanup for owned event loops."""
+        try:
+            self.close()
+        except Exception:
+            pass
 
 
 def create_async_backend(data_root: Path, **kwargs) -> AsyncFileSystemBackend:

--- a/src/ml4t/data/storage/filesystem.py
+++ b/src/ml4t/data/storage/filesystem.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import json
 import os
 import time
-import warnings
 from pathlib import Path
 
 import filelock
@@ -54,12 +53,6 @@ class FileSystemBackend(StorageBackend):
             max_retries: Maximum number of lock acquisition retries
             retry_base_delay: Base delay for exponential backoff (seconds)
         """
-        warnings.warn(
-            "FileSystemBackend is deprecated and will be removed in v1.0. "
-            "Use HiveStorage instead for better performance.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         self.data_root = Path(data_root)
         self.data_root.mkdir(parents=True, exist_ok=True)
 

--- a/src/ml4t/data/storage/flat.py
+++ b/src/ml4t/data/storage/flat.py
@@ -16,6 +16,8 @@ import polars as pl
 from filelock import FileLock
 
 from .backend import StorageBackend, StorageConfig
+from .key_codec import decode_storage_key, encode_storage_key
+from .manifest import manifest_from_write, normalize_manifest_payload, upgrade_manifest_payload
 
 
 class FlatStorage(StorageBackend):
@@ -39,6 +41,46 @@ class FlatStorage(StorageBackend):
         self.metadata_dir = self.base_path / ".metadata"
         self.metadata_dir.mkdir(exist_ok=True)
 
+    def _encoded_data_path(self, key: str) -> Path:
+        """Return encoded data file path."""
+        return self.base_path / f"{encode_storage_key(key)}.parquet"
+
+    def _legacy_data_path(self, key: str) -> Path:
+        """Return legacy data file path."""
+        return self.base_path / f"{key.replace('/', '_')}.parquet"
+
+    def _resolve_existing_data_path(self, key: str) -> Path | None:
+        """Resolve existing data file path, preferring encoded format."""
+        encoded = self._encoded_data_path(key)
+        if encoded.exists():
+            return encoded
+
+        legacy = self._legacy_data_path(key)
+        if legacy.exists():
+            return legacy
+
+        return None
+
+    def _encoded_metadata_path(self, key: str) -> Path:
+        """Return encoded metadata file path."""
+        return self.metadata_dir / f"{encode_storage_key(key)}.json"
+
+    def _legacy_metadata_path(self, key: str) -> Path:
+        """Return legacy metadata file path."""
+        return self.metadata_dir / f"{key.replace('/', '_')}.json"
+
+    def _resolve_existing_metadata_path(self, key: str) -> Path | None:
+        """Resolve existing metadata file path, preferring encoded format."""
+        encoded = self._encoded_metadata_path(key)
+        if encoded.exists():
+            return encoded
+
+        legacy = self._legacy_metadata_path(key)
+        if legacy.exists():
+            return legacy
+
+        return None
+
     def write(
         self, data: pl.LazyFrame | pl.DataFrame, key: str, metadata: dict[str, Any] | None = None
     ) -> Path:
@@ -56,7 +98,7 @@ class FlatStorage(StorageBackend):
         lazy_data = self._ensure_lazy(data)
 
         # Create file path
-        file_path = self.base_path / f"{key.replace('/', '_')}.parquet"
+        file_path = self._encoded_data_path(key)
 
         # Collect and write atomically
         df = lazy_data.collect()
@@ -66,14 +108,16 @@ class FlatStorage(StorageBackend):
         if self.config.metadata_tracking:
             self._update_metadata(
                 key,
-                {
-                    "last_updated": datetime.now().isoformat(),
-                    "file_path": str(file_path.relative_to(self.base_path)),
-                    "row_count": len(df),
-                    "schema": list(df.columns),
-                    "file_size_mb": file_path.stat().st_size / (1024 * 1024),
-                    "custom": metadata or {},
-                },
+                manifest_from_write(
+                    key,
+                    row_count=len(df),
+                    schema=list(df.columns),
+                    custom=metadata or {},
+                    range_start=df["timestamp"].min() if "timestamp" in df.columns else None,
+                    range_end=df["timestamp"].max() if "timestamp" in df.columns else None,
+                    file_path=str(file_path.relative_to(self.base_path)),
+                    file_size_mb=file_path.stat().st_size / (1024 * 1024),
+                ),
             )
 
         return file_path
@@ -96,9 +140,8 @@ class FlatStorage(StorageBackend):
         Returns:
             LazyFrame with requested data
         """
-        file_path = self.base_path / f"{key.replace('/', '_')}.parquet"
-
-        if not file_path.exists():
+        file_path = self._resolve_existing_data_path(key)
+        if file_path is None:
             raise KeyError(f"Key '{key}' not found in storage")
 
         # Use lazy reading
@@ -109,7 +152,7 @@ class FlatStorage(StorageBackend):
             lf = lf.select(columns)
 
         # Apply date filters if timestamp column exists
-        schema = lf.schema
+        schema = lf.collect_schema()
         if "timestamp" in schema:
             if start_date:
                 lf = lf.filter(pl.col("timestamp") >= start_date)
@@ -126,9 +169,7 @@ class FlatStorage(StorageBackend):
         """
         keys = []
         for path in self.base_path.glob("*.parquet"):
-            # Convert from filesystem-safe name
-            key = path.stem.replace("_", "/")
-            keys.append(key)
+            keys.append(decode_storage_key(path.stem))
         return sorted(keys)
 
     def exists(self, key: str) -> bool:
@@ -140,8 +181,7 @@ class FlatStorage(StorageBackend):
         Returns:
             True if key exists
         """
-        file_path = self.base_path / f"{key.replace('/', '_')}.parquet"
-        return file_path.exists()
+        return self._resolve_existing_data_path(key) is not None
 
     def delete(self, key: str) -> bool:
         """Delete data for a key.
@@ -152,17 +192,18 @@ class FlatStorage(StorageBackend):
         Returns:
             True if successful
         """
-        file_path = self.base_path / f"{key.replace('/', '_')}.parquet"
-        if file_path.exists():
+        deleted = False
+        file_path = self._resolve_existing_data_path(key)
+        if file_path is not None:
             file_path.unlink()
+            deleted = True
 
-            # Remove metadata
-            metadata_file = self.metadata_dir / f"{key.replace('/', '_')}.json"
+        for metadata_file in (self._encoded_metadata_path(key), self._legacy_metadata_path(key)):
             if metadata_file.exists():
                 metadata_file.unlink()
+                deleted = True
 
-            return True
-        return False
+        return deleted
 
     def get_metadata(self, key: str) -> dict[str, Any] | None:
         """Get metadata for a key.
@@ -173,11 +214,19 @@ class FlatStorage(StorageBackend):
         Returns:
             Metadata dict or None
         """
-        metadata_file = self.metadata_dir / f"{key.replace('/', '_')}.json"
-        if metadata_file.exists():
-            with open(metadata_file) as f:
-                return json.load(f)
-        return None
+        metadata_file = self._resolve_existing_metadata_path(key)
+        if metadata_file is None:
+            return None
+        with open(metadata_file) as f:
+            raw = json.load(f)
+        upgraded, changed = upgrade_manifest_payload(
+            key,
+            raw,
+            emit_deprecation_warning=True,
+        )
+        if changed:
+            self._update_metadata(key, upgraded)
+        return normalize_manifest_payload(key, upgraded)
 
     def _atomic_write(self, df: pl.DataFrame, target_path: Path) -> None:
         """Write DataFrame atomically using temp file pattern.
@@ -187,16 +236,20 @@ class FlatStorage(StorageBackend):
             target_path: Target file path
         """
         # Write to temp file first
-        with tempfile.NamedTemporaryFile(
-            dir=target_path.parent, suffix=".parquet.tmp", delete=False
-        ) as tmp_file:
-            tmp_path = Path(tmp_file.name)
+        tmp_path: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                dir=target_path.parent, suffix=".parquet.tmp", delete=False
+            ) as tmp_file:
+                tmp_path = Path(tmp_file.name)
+                df.write_parquet(tmp_path, compression=self.config.compression or "zstd")
 
-            # Write with compression
-            df.write_parquet(tmp_path, compression=self.config.compression or "zstd")
-
-            # Atomic rename
-            tmp_path.replace(target_path)
+            if tmp_path is not None:
+                tmp_path.replace(target_path)
+        except Exception:
+            if tmp_path is not None and tmp_path.exists():
+                tmp_path.unlink()
+            raise
 
     def _update_metadata(self, key: str, metadata: dict[str, Any]) -> None:
         """Update metadata for a key.
@@ -205,10 +258,10 @@ class FlatStorage(StorageBackend):
             key: Storage key
             metadata: Metadata to store
         """
-        metadata_file = self.metadata_dir / f"{key.replace('/', '_')}.json"
+        metadata_file = self._encoded_metadata_path(key)
 
         if self.config.enable_locking:
-            lock_file = self.metadata_dir / f"{key.replace('/', '_')}.lock"
+            lock_file = self.metadata_dir / f"{encode_storage_key(key)}.lock"
             lock = FileLock(lock_file, timeout=10)
 
             with lock:
@@ -223,9 +276,17 @@ class FlatStorage(StorageBackend):
             path: Metadata file path
             metadata: Metadata to write
         """
-        with tempfile.NamedTemporaryFile(
-            dir=path.parent, mode="w", suffix=".json.tmp", delete=False
-        ) as tmp_file:
-            json.dump(metadata, tmp_file, indent=2, default=str)
-            tmp_path = Path(tmp_file.name)
-            tmp_path.replace(path)
+        tmp_path: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                dir=path.parent, mode="w", suffix=".json.tmp", delete=False
+            ) as tmp_file:
+                tmp_path = Path(tmp_file.name)
+                json.dump(metadata, tmp_file, indent=2, default=str)
+
+            if tmp_path is not None:
+                tmp_path.replace(path)
+        except Exception:
+            if tmp_path is not None and tmp_path.exists():
+                tmp_path.unlink()
+            raise

--- a/src/ml4t/data/storage/hive.py
+++ b/src/ml4t/data/storage/hive.py
@@ -17,6 +17,13 @@ import polars as pl
 from filelock import FileLock
 
 from .backend import StorageBackend, StorageConfig
+from .key_codec import decode_storage_key, encode_storage_key
+from .manifest import (
+    manifest_from_write,
+    manifest_with_incremental_update,
+    normalize_manifest_payload,
+    upgrade_manifest_payload,
+)
 
 if TYPE_CHECKING:
     from ml4t.data.core.models import DataObject
@@ -56,6 +63,46 @@ class HiveStorage(StorageBackend):
         super().__init__(config)
         self.metadata_dir = self.base_path / ".metadata"
         self.metadata_dir.mkdir(exist_ok=True)
+
+    def _encoded_key_path(self, key: str) -> Path:
+        """Return encoded key directory path."""
+        return self.base_path / encode_storage_key(key)
+
+    def _legacy_key_path(self, key: str) -> Path:
+        """Return legacy slash-to-underscore key directory path."""
+        return self.base_path / key.replace("/", "_")
+
+    def _resolve_existing_key_path(self, key: str) -> Path | None:
+        """Resolve existing key path, preferring encoded format."""
+        encoded = self._encoded_key_path(key)
+        if encoded.exists():
+            return encoded
+
+        legacy = self._legacy_key_path(key)
+        if legacy.exists():
+            return legacy
+
+        return None
+
+    def _encoded_metadata_path(self, key: str) -> Path:
+        """Return encoded metadata file path."""
+        return self.metadata_dir / f"{encode_storage_key(key)}.json"
+
+    def _legacy_metadata_path(self, key: str) -> Path:
+        """Return legacy metadata file path."""
+        return self.metadata_dir / f"{key.replace('/', '_')}.json"
+
+    def _resolve_existing_metadata_path(self, key: str) -> Path | None:
+        """Resolve existing metadata file path, preferring encoded format."""
+        encoded = self._encoded_metadata_path(key)
+        if encoded.exists():
+            return encoded
+
+        legacy = self._legacy_metadata_path(key)
+        if legacy.exists():
+            return legacy
+
+        return None
 
     def _get_partition_columns(self) -> list[str]:
         """Get partition column names based on configured granularity.
@@ -299,7 +346,7 @@ class HiveStorage(StorageBackend):
         df = self._add_partition_columns(df, partition_cols)
 
         # Create key directory
-        key_path = self.base_path / key.replace("/", "_")
+        key_path = self._encoded_key_path(key)
         key_path.mkdir(exist_ok=True)
 
         # Group by partitions and write
@@ -322,13 +369,15 @@ class HiveStorage(StorageBackend):
         if self.config.metadata_tracking:
             self._update_metadata(
                 key,
-                {
-                    "last_updated": datetime.now().isoformat(),
-                    "partitions": partitions_written,
-                    "row_count": len(df),
-                    "schema": list(df.columns),
-                    "custom": metadata or {},
-                },
+                manifest_from_write(
+                    key,
+                    row_count=len(df),
+                    schema=list(df.columns),
+                    custom=metadata or {},
+                    range_start=df["timestamp"].min(),
+                    range_end=df["timestamp"].max(),
+                    partitions=partitions_written,
+                ),
             )
 
         return key_path
@@ -351,9 +400,8 @@ class HiveStorage(StorageBackend):
         Returns:
             LazyFrame with requested data
         """
-        key_path = self.base_path / key.replace("/", "_")
-
-        if not key_path.exists():
+        key_path = self._resolve_existing_key_path(key)
+        if key_path is None:
             raise KeyError(f"Key '{key}' not found in storage")
 
         # Get partition columns based on granularity
@@ -396,8 +444,7 @@ class HiveStorage(StorageBackend):
         keys = []
         for path in self.base_path.iterdir():
             if path.is_dir() and not path.name.startswith("."):
-                # Convert back from filesystem-safe name
-                keys.append(path.name.replace("_", "/"))
+                keys.append(decode_storage_key(path.name))
         return sorted(keys)
 
     def exists(self, key: str) -> bool:
@@ -409,8 +456,7 @@ class HiveStorage(StorageBackend):
         Returns:
             True if key exists
         """
-        key_path = self.base_path / key.replace("/", "_")
-        return key_path.exists()
+        return self._resolve_existing_key_path(key) is not None
 
     def delete(self, key: str) -> bool:
         """Delete all data for a key.
@@ -421,17 +467,19 @@ class HiveStorage(StorageBackend):
         Returns:
             True if successful
         """
-        key_path = self.base_path / key.replace("/", "_")
-        if key_path.exists():
+        key_path = self._resolve_existing_key_path(key)
+        deleted = False
+        if key_path is not None:
             shutil.rmtree(key_path)
+            deleted = True
 
-            # Remove metadata
-            metadata_file = self.metadata_dir / f"{key.replace('/', '_')}.json"
+        # Remove metadata in both new and legacy locations.
+        for metadata_file in (self._encoded_metadata_path(key), self._legacy_metadata_path(key)):
             if metadata_file.exists():
                 metadata_file.unlink()
+                deleted = True
 
-            return True
-        return False
+        return deleted
 
     def get_metadata(self, key: str) -> dict[str, Any] | None:
         """Get metadata for a key.
@@ -442,11 +490,19 @@ class HiveStorage(StorageBackend):
         Returns:
             Metadata dict or None
         """
-        metadata_file = self.metadata_dir / f"{key.replace('/', '_')}.json"
-        if metadata_file.exists():
-            with open(metadata_file) as f:
-                return json.load(f)
-        return None
+        metadata_file = self._resolve_existing_metadata_path(key)
+        if metadata_file is None:
+            return None
+        with open(metadata_file) as f:
+            raw = json.load(f)
+        upgraded, changed = upgrade_manifest_payload(
+            key,
+            raw,
+            emit_deprecation_warning=True,
+        )
+        if changed:
+            self._update_metadata(key, upgraded)
+        return normalize_manifest_payload(key, upgraded)
 
     def _atomic_write(self, df: pl.DataFrame, target_path: Path) -> None:
         """Write DataFrame atomically using temp file pattern.
@@ -456,16 +512,20 @@ class HiveStorage(StorageBackend):
             target_path: Target file path
         """
         # Write to temp file first
-        with tempfile.NamedTemporaryFile(
-            dir=target_path.parent, suffix=".parquet.tmp", delete=False
-        ) as tmp_file:
-            tmp_path = Path(tmp_file.name)
+        tmp_path: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                dir=target_path.parent, suffix=".parquet.tmp", delete=False
+            ) as tmp_file:
+                tmp_path = Path(tmp_file.name)
+                df.write_parquet(tmp_path, compression=self.config.compression or "zstd")
 
-            # Write with compression
-            df.write_parquet(tmp_path, compression=self.config.compression or "zstd")
-
-            # Atomic rename
-            tmp_path.replace(target_path)
+            if tmp_path is not None:
+                tmp_path.replace(target_path)
+        except Exception:
+            if tmp_path is not None and tmp_path.exists():
+                tmp_path.unlink()
+            raise
 
     def _update_metadata(self, key: str, metadata: dict[str, Any]) -> None:
         """Update metadata for a key.
@@ -474,10 +534,10 @@ class HiveStorage(StorageBackend):
             key: Storage key
             metadata: Metadata to store
         """
-        metadata_file = self.metadata_dir / f"{key.replace('/', '_')}.json"
+        metadata_file = self._encoded_metadata_path(key)
 
         if self.config.enable_locking:
-            lock_file = self.metadata_dir / f"{key.replace('/', '_')}.lock"
+            lock_file = self.metadata_dir / f"{encode_storage_key(key)}.lock"
             lock = FileLock(lock_file, timeout=10)
 
             with lock:
@@ -492,12 +552,20 @@ class HiveStorage(StorageBackend):
             path: Metadata file path
             metadata: Metadata to write
         """
-        with tempfile.NamedTemporaryFile(
-            dir=path.parent, mode="w", suffix=".json.tmp", delete=False
-        ) as tmp_file:
-            json.dump(metadata, tmp_file, indent=2, default=str)
-            tmp_path = Path(tmp_file.name)
-            tmp_path.replace(path)
+        tmp_path: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                dir=path.parent, mode="w", suffix=".json.tmp", delete=False
+            ) as tmp_file:
+                tmp_path = Path(tmp_file.name)
+                json.dump(metadata, tmp_file, indent=2, default=str)
+
+            if tmp_path is not None:
+                tmp_path.replace(path)
+        except Exception:
+            if tmp_path is not None and tmp_path.exists():
+                tmp_path.unlink()
+            raise
 
     # Incremental update methods for IncrementalStorageBackend protocol
 
@@ -578,21 +646,23 @@ class HiveStorage(StorageBackend):
         key = f"{provider}/{symbol}"
 
         # Read existing data
+        existing_rows = 0
         if self.exists(key):
             existing_df = self.read(key).collect()
+            existing_rows = len(existing_df)
             combined = pl.concat([existing_df, data])
         else:
             combined = data
 
         # Deduplicate by timestamp, keeping latest
-        rows_before = len(combined)
         combined = combined.unique(subset=["timestamp"], keep="last").sort("timestamp")
         rows_after = len(combined)
+        rows_added = max(0, rows_after - existing_rows)
 
         # Write back to storage (correct parameter order: data, key, metadata)
         self.write(combined, key)
 
-        return rows_after - rows_before
+        return rows_added
 
     def get_combined_file_path(self, symbol: str, provider: str) -> Path:
         """Get path to the main combined data directory.
@@ -605,7 +675,7 @@ class HiveStorage(StorageBackend):
             Path to combined data directory
         """
         key = f"{provider}/{symbol}"
-        return self.base_path / key.replace("/", "_")
+        return self._encoded_key_path(key)
 
     def read_data(
         self,
@@ -650,38 +720,24 @@ class HiveStorage(StorageBackend):
             chunk_file: Name of the chunk file saved
         """
         key = f"{provider}/{symbol}"
-        metadata_file = self.metadata_dir / f"{key.replace('/', '_')}.json"
+        metadata_file = self._encoded_metadata_path(key)
 
         # Load existing metadata or create new
+        existing: dict[str, Any] | None = None
         if metadata_file.exists():
             with open(metadata_file) as f:
-                metadata = json.load(f)
-        else:
-            metadata = {
-                "symbol": symbol,
-                "provider": provider,
-                "first_update": last_update.isoformat(),
-                "update_history": [],
-            }
-
-        # Update metadata
-        metadata["last_update"] = last_update.isoformat()
-
-        # Ensure update_history exists
-        if "update_history" not in metadata:
-            metadata["update_history"] = []
-
-        metadata["update_history"].append(
-            {
-                "timestamp": last_update.isoformat(),
-                "records_added": records_added,
-                "chunk_file": chunk_file,
-            }
-        )
-
-        # Keep only last 100 updates in history
-        if len(metadata["update_history"]) > 100:
-            metadata["update_history"] = metadata["update_history"][-100:]
+                existing = json.load(f)
 
         # Write metadata
+        metadata = manifest_with_incremental_update(
+            key,
+            existing
+            or {
+                "provider": provider,
+                "symbol": symbol,
+            },
+            last_update=last_update,
+            records_added=records_added,
+            chunk_file=chunk_file,
+        )
         self._update_metadata(key, metadata)

--- a/src/ml4t/data/storage/key_codec.py
+++ b/src/ml4t/data/storage/key_codec.py
@@ -1,0 +1,36 @@
+"""Storage key encoding helpers.
+
+This module provides a reversible encoding for storage keys so filesystem
+names remain unambiguous. It also supports decoding legacy names used before
+encoded keys were introduced.
+"""
+
+from __future__ import annotations
+
+import base64
+
+ENCODED_PREFIX = "k__"
+
+
+def encode_storage_key(key: str) -> str:
+    """Encode a storage key to a filesystem-safe directory/file name."""
+    raw = key.encode("utf-8")
+    encoded = base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+    return f"{ENCODED_PREFIX}{encoded}"
+
+
+def is_encoded_storage_key(value: str) -> bool:
+    """Return True if the value uses the encoded key format."""
+    return value.startswith(ENCODED_PREFIX)
+
+
+def decode_storage_key(value: str) -> str:
+    """Decode either encoded key names or legacy slash-to-underscore names."""
+    if not is_encoded_storage_key(value):
+        return value.replace("_", "/")
+
+    payload = value[len(ENCODED_PREFIX) :]
+    padding = "=" * (-len(payload) % 4)
+    raw = base64.urlsafe_b64decode(payload + padding)
+    return raw.decode("utf-8")
+

--- a/src/ml4t/data/storage/manifest.py
+++ b/src/ml4t/data/storage/manifest.py
@@ -1,0 +1,280 @@
+"""Canonical manifest contract helpers for storage metadata."""
+
+from __future__ import annotations
+
+import warnings
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from ml4t.data.core.keys import is_storage_key, parse_storage_key
+
+MANIFEST_VERSION = "1.0"
+
+
+def _parse_key(key: str) -> tuple[str, str, str]:
+    """Parse canonical storage key into parts, with simple-key fallback."""
+    if is_storage_key(key):
+        return parse_storage_key(key)
+    return "", "", key
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    """Parse datetime values from common metadata payload formats."""
+    if isinstance(value, datetime):
+        return value
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _to_iso(value: Any) -> str:
+    """Convert datetime-like values to ISO string, returning empty string when missing."""
+    parsed = _parse_datetime(value)
+    if parsed is None:
+        return ""
+    return parsed.isoformat()
+
+
+def _coerce_int(value: Any, default: int = 0) -> int:
+    """Coerce integer-like values while keeping invalid inputs safe."""
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return default
+    return default
+
+
+class ManifestV1(BaseModel):
+    """Canonical storage metadata manifest."""
+
+    manifest_version: str = MANIFEST_VERSION
+    key: str
+    provider: str = ""
+    symbol: str = ""
+    asset_class: str = ""
+    frequency: str = ""
+    exchange: str = ""
+    bar_type: str = ""
+    row_count: int = 0
+    total_rows: int = 0
+    data_range: dict[str, str] = Field(default_factory=dict)
+    last_updated: str = ""
+    last_update: str = ""
+    first_update: str = ""
+    update_history: list[dict[str, Any]] = Field(default_factory=list)
+    schema_columns: list[str] = Field(default_factory=list, alias="schema")
+    partitions: list[str] = Field(default_factory=list)
+    file_path: str = ""
+    file_size_mb: float = 0.0
+    custom: dict[str, Any] = Field(default_factory=dict)
+
+    model_config = {"extra": "allow", "populate_by_name": True}
+
+    @classmethod
+    def from_payload(
+        cls,
+        key: str,
+        payload: dict[str, Any] | None,
+    ) -> ManifestV1:
+        """Normalize arbitrary manifest payload into canonical contract."""
+        raw = payload or {}
+        custom = raw.get("custom")
+        if not isinstance(custom, dict):
+            custom = {}
+
+        key_asset_class, key_frequency, key_symbol = _parse_key(key)
+        provider = raw.get("provider") or custom.get("provider") or ""
+        symbol = raw.get("symbol") or custom.get("symbol") or key_symbol
+        asset_class = raw.get("asset_class") or custom.get("asset_class") or key_asset_class
+        frequency = raw.get("frequency") or custom.get("frequency") or key_frequency
+        exchange = raw.get("exchange") or custom.get("exchange") or ""
+        bar_type = raw.get("bar_type") or custom.get("bar_type") or ""
+
+        raw_data_range = raw.get("data_range")
+        if not isinstance(raw_data_range, dict):
+            raw_data_range = {}
+
+        start = (
+            raw_data_range.get("start")
+            or raw_data_range.get("start_date")
+            or custom.get("start_date")
+            or custom.get("start")
+        )
+        end = (
+            raw_data_range.get("end")
+            or raw_data_range.get("end_date")
+            or custom.get("end_date")
+            or custom.get("end")
+        )
+
+        last_updated = (
+            raw.get("last_updated")
+            or raw.get("last_update")
+            or raw.get("download_utc_timestamp")
+            or custom.get("last_updated")
+            or custom.get("last_update")
+            or ""
+        )
+        first_update = raw.get("first_update") or raw.get("download_utc_timestamp") or last_updated
+        row_count = _coerce_int(raw.get("row_count", raw.get("total_rows", 0)))
+
+        update_history = raw.get("update_history")
+        if not isinstance(update_history, list):
+            update_history = []
+
+        schema = raw.get("schema")
+        if not isinstance(schema, list):
+            schema = []
+
+        partitions = raw.get("partitions")
+        if not isinstance(partitions, list):
+            partitions = []
+
+        return cls(
+            manifest_version=str(raw.get("manifest_version", MANIFEST_VERSION)),
+            key=key,
+            provider=provider,
+            symbol=symbol,
+            asset_class=asset_class,
+            frequency=frequency,
+            exchange=exchange,
+            bar_type=bar_type,
+            row_count=row_count,
+            total_rows=row_count,
+            data_range={"start": _to_iso(start), "end": _to_iso(end)},
+            last_updated=_to_iso(last_updated),
+            last_update=_to_iso(last_updated),
+            first_update=_to_iso(first_update),
+            update_history=update_history,
+            schema_columns=schema,
+            partitions=partitions,
+            file_path=str(raw.get("file_path", "")),
+            file_size_mb=float(raw.get("file_size_mb", 0.0) or 0.0),
+            custom=custom,
+        )
+
+
+def manifest_from_write(
+    key: str,
+    row_count: int,
+    schema: list[str],
+    custom: dict[str, Any] | None = None,
+    *,
+    range_start: Any = None,
+    range_end: Any = None,
+    partitions: list[str] | None = None,
+    file_path: str | None = None,
+    file_size_mb: float | None = None,
+) -> dict[str, Any]:
+    """Create canonical manifest payload for write operations."""
+    now = datetime.now().isoformat()
+    base = ManifestV1.from_payload(key, {"custom": custom or {}})
+    payload = base.model_dump(by_alias=True)
+    payload["manifest_version"] = MANIFEST_VERSION
+    payload["row_count"] = row_count
+    payload["total_rows"] = row_count
+    payload["schema"] = schema
+    payload["last_updated"] = now
+    payload["last_update"] = now
+    payload["first_update"] = payload.get("first_update") or now
+
+    data_range = {
+        "start": _to_iso(range_start) or payload["data_range"].get("start", ""),
+        "end": _to_iso(range_end) or payload["data_range"].get("end", ""),
+    }
+    payload["data_range"] = data_range
+
+    if partitions is not None:
+        payload["partitions"] = partitions
+    if file_path is not None:
+        payload["file_path"] = file_path
+    if file_size_mb is not None:
+        payload["file_size_mb"] = file_size_mb
+
+    return payload
+
+
+def upgrade_manifest_payload(
+    key: str,
+    payload: dict[str, Any] | None,
+    *,
+    emit_deprecation_warning: bool = False,
+) -> tuple[dict[str, Any], bool]:
+    """Upgrade legacy manifests to the canonical v1 contract."""
+    raw = payload or {}
+    current_version = raw.get("manifest_version")
+    normalized = ManifestV1.from_payload(key, raw).model_dump(by_alias=True)
+    normalized["manifest_version"] = MANIFEST_VERSION
+
+    changed = normalized != raw
+
+    if emit_deprecation_warning and current_version != MANIFEST_VERSION:
+        if current_version is None:
+            warnings.warn(
+                "Legacy manifest without 'manifest_version' detected; upgraded to 1.0.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        else:
+            warnings.warn(
+                f"Legacy manifest version '{current_version}' detected; upgraded to 1.0.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+    return normalized, changed
+
+
+def manifest_with_incremental_update(
+    key: str,
+    payload: dict[str, Any] | None,
+    *,
+    last_update: datetime,
+    records_added: int,
+    chunk_file: str,
+    max_history: int = 100,
+) -> dict[str, Any]:
+    """Apply incremental update metadata onto manifest payload."""
+    normalized, _ = upgrade_manifest_payload(key, payload)
+
+    normalized["manifest_version"] = MANIFEST_VERSION
+    normalized["last_updated"] = last_update.isoformat()
+    normalized["last_update"] = last_update.isoformat()
+    if not normalized.get("first_update"):
+        normalized["first_update"] = last_update.isoformat()
+
+    history = normalized.get("update_history")
+    if not isinstance(history, list):
+        history = []
+    history.append(
+        {
+            "timestamp": last_update.isoformat(),
+            "records_added": records_added,
+            "chunk_file": chunk_file,
+        }
+    )
+    normalized["update_history"] = history[-max_history:]
+
+    return normalized
+
+
+def normalize_manifest_payload(key: str, payload: dict[str, Any] | None) -> dict[str, Any]:
+    """Normalize payload and expose compatibility aliases used across the codebase."""
+    normalized, _ = upgrade_manifest_payload(key, payload)
+    update_history = normalized.get("update_history")
+    update_count = len(update_history) if isinstance(update_history, list) else 0
+    normalized["update_count"] = update_count
+    normalized["attributes"] = {"last_update": normalized.get("last_updated", "")}
+    return normalized

--- a/src/ml4t/data/storage/metadata_tracker.py
+++ b/src/ml4t/data/storage/metadata_tracker.py
@@ -10,6 +10,8 @@ from typing import Any
 
 import structlog
 
+from ml4t.data.storage.key_codec import decode_storage_key, encode_storage_key
+from ml4t.data.storage.manifest import normalize_manifest_payload
 from ml4t.data.utils.locking import file_lock
 
 logger = structlog.get_logger()
@@ -131,6 +133,17 @@ class DatasetMetadata:
         )
 
 
+@dataclass
+class DatasetUpdate:
+    """Latest update snapshot for CLI health/info views."""
+
+    symbol: str
+    provider: str
+    frequency: str
+    timestamp: datetime
+    asset_class: str = ""
+
+
 class MetadataTracker:
     """Track metadata and update history for datasets."""
 
@@ -155,6 +168,114 @@ class MetadataTracker:
         safe_key = key.replace("/", "_")
         return self.metadata_dir / f"{safe_key}_history.json"
 
+    def _manifest_metadata_paths(self, key: str) -> list[Path]:
+        """Get possible storage manifest paths for a dataset key."""
+        return [
+            self.metadata_dir / f"{encode_storage_key(key)}.json",
+            self.metadata_dir / f"{key.replace('/', '_')}.json",
+        ]
+
+    def _parse_datetime(self, value: Any) -> datetime | None:
+        """Parse datetime values from metadata payloads."""
+        if isinstance(value, datetime):
+            return value
+        if not isinstance(value, str) or not value:
+            return None
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+
+    def _metadata_from_manifest(
+        self,
+        key: str,
+        payload: dict[str, Any],
+    ) -> DatasetMetadata | None:
+        """Convert storage manifest metadata into DatasetMetadata shape."""
+        normalized = normalize_manifest_payload(key, payload)
+        last_update = self._parse_datetime(normalized.get("last_updated"))
+        first_update = self._parse_datetime(normalized.get("first_update")) or last_update
+
+        data_range = normalized.get("data_range")
+        if not isinstance(data_range, dict):
+            data_range = {}
+
+        range_start = self._parse_datetime(data_range.get("start")) or first_update
+        range_end = self._parse_datetime(data_range.get("end")) or last_update
+
+        if not last_update or not first_update or not range_start or not range_end:
+            return None
+
+        update_count = normalized.get("update_count")
+        if not isinstance(update_count, int):
+            update_count = 1
+
+        row_count = normalized.get("total_rows", normalized.get("row_count", 0))
+        if not isinstance(row_count, int):
+            row_count = 0
+
+        return DatasetMetadata(
+            symbol=str(normalized.get("symbol", "")),
+            asset_class=str(normalized.get("asset_class", "")),
+            frequency=str(normalized.get("frequency", "")),
+            provider=str(normalized.get("provider", "")),
+            first_update=first_update,
+            last_update=last_update,
+            total_rows=row_count,
+            date_range_start=range_start,
+            date_range_end=range_end,
+            update_count=update_count,
+            last_check=self._parse_datetime(normalized.get("last_check")),
+            health_status=str(normalized.get("health_status", "healthy")),
+            health_message=str(normalized.get("health_message", "")),
+        )
+
+    def _load_metadata_file(self, metadata_file: Path) -> tuple[str, DatasetMetadata] | None:
+        """Load one metadata file and return canonical key plus metadata."""
+        if metadata_file.name.endswith("_history.json"):
+            return None
+
+        with open(metadata_file) as f:
+            payload = json.load(f)
+
+        if metadata_file.name.endswith("_metadata.json"):
+            metadata = DatasetMetadata.from_dict(payload)
+            if metadata.asset_class and metadata.frequency and metadata.symbol:
+                key = f"{metadata.asset_class}/{metadata.frequency}/{metadata.symbol}"
+            else:
+                key = metadata.symbol
+            return key, metadata
+
+        decoded_key = decode_storage_key(metadata_file.stem)
+        metadata = self._metadata_from_manifest(decoded_key, payload)
+        if metadata is None:
+            return None
+
+        if metadata.asset_class and metadata.frequency and metadata.symbol:
+            key = f"{metadata.asset_class}/{metadata.frequency}/{metadata.symbol}"
+        else:
+            key = decoded_key
+        return key, metadata
+
+    def _collect_all_metadata(self) -> list[DatasetMetadata]:
+        """Collect metadata from tracker and storage manifest files."""
+        by_key: dict[str, tuple[int, DatasetMetadata]] = {}
+
+        for metadata_file in self.metadata_dir.glob("*.json"):
+            try:
+                loaded = self._load_metadata_file(metadata_file)
+                if loaded is None:
+                    continue
+                key, metadata = loaded
+                priority = 2 if metadata_file.name.endswith("_metadata.json") else 1
+                existing = by_key.get(key)
+                if existing is None or priority >= existing[0]:
+                    by_key[key] = (priority, metadata)
+            except Exception as e:
+                logger.warning(f"Failed to load metadata from {metadata_file}: {e}")
+
+        return [value[1] for _, value in sorted(by_key.items(), key=lambda item: item[0])]
+
     def get_metadata(self, key: str) -> DatasetMetadata | None:
         """
         Get metadata for a dataset.
@@ -166,14 +287,21 @@ class MetadataTracker:
             DatasetMetadata if exists, None otherwise
         """
         metadata_path = self._get_metadata_path(key)
+        if metadata_path.exists():
+            with file_lock(metadata_path), open(metadata_path) as f:
+                data = json.load(f)
+            return DatasetMetadata.from_dict(data)
 
-        if not metadata_path.exists():
-            return None
+        for manifest_path in self._manifest_metadata_paths(key):
+            if not manifest_path.exists():
+                continue
+            with file_lock(manifest_path), open(manifest_path) as f:
+                manifest = json.load(f)
+            metadata = self._metadata_from_manifest(key, manifest)
+            if metadata is not None:
+                return metadata
 
-        with file_lock(metadata_path), open(metadata_path) as f:
-            data = json.load(f)
-
-        return DatasetMetadata.from_dict(data)
+        return None
 
     def update_metadata(
         self,
@@ -360,22 +488,15 @@ class MetadataTracker:
         Returns:
             Dictionary with summary statistics
         """
-        all_metadata = []
-
-        # Load all metadata files
-        for metadata_file in self.metadata_dir.glob("*_metadata.json"):
-            try:
-                with open(metadata_file) as f:
-                    data = json.load(f)
-                all_metadata.append(DatasetMetadata.from_dict(data))
-            except Exception as e:
-                logger.warning(f"Failed to load metadata from {metadata_file}: {e}")
+        all_metadata = self._collect_all_metadata()
 
         # Calculate summary
         total_datasets = len(all_metadata)
         healthy = sum(1 for m in all_metadata if m.health_status == "healthy")
         stale = sum(1 for m in all_metadata if m.health_status == "stale")
         error = sum(1 for m in all_metadata if m.health_status == "error")
+        unique_providers = len({m.provider for m in all_metadata if m.provider})
+        unique_symbols = len({m.symbol for m in all_metadata if m.symbol})
 
         total_rows = sum(m.total_rows for m in all_metadata)
         total_updates = sum(m.update_count for m in all_metadata)
@@ -394,6 +515,23 @@ class MetadataTracker:
             "error": error,
             "total_rows": total_rows,
             "total_updates": total_updates,
+            "unique_providers": unique_providers,
+            "unique_symbols": unique_symbols,
             "by_asset_class": by_asset_class,
             "last_updated": datetime.now().isoformat(),
         }
+
+    def list_updates(self) -> list[DatasetUpdate]:
+        """List latest updates for all tracked datasets (most recent first)."""
+        all_metadata = self._collect_all_metadata()
+        updates = [
+            DatasetUpdate(
+                symbol=metadata.symbol,
+                provider=metadata.provider,
+                frequency=metadata.frequency,
+                timestamp=metadata.last_update,
+                asset_class=metadata.asset_class,
+            )
+            for metadata in all_metadata
+        ]
+        return sorted(updates, key=lambda x: x.timestamp, reverse=True)

--- a/src/ml4t/data/storage/transaction.py
+++ b/src/ml4t/data/storage/transaction.py
@@ -9,11 +9,11 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
+from typing import Any
 
 import structlog
 
 from ml4t.data.core.models import DataObject
-from ml4t.data.storage.base import StorageBackend
 
 logger = structlog.get_logger()
 
@@ -34,12 +34,22 @@ class TransactionOperation:
     operation_type: str  # "write", "update", "delete"
     key: str
     data: DataObject | None = None
-    backup_data: DataObject | None = None
+    backup_data: BackupSnapshot | None = None
+    result_key: str | None = None
     timestamp: datetime = field(default_factory=datetime.now)
 
 
 class TransactionError(Exception):
     """Raised when a transaction operation fails."""
+
+
+@dataclass
+class BackupSnapshot:
+    """Snapshot of existing data and metadata for rollback."""
+
+    key: str
+    data: Any
+    metadata: dict[str, Any] | None = None
 
 
 class Transaction:
@@ -52,7 +62,7 @@ class Transaction:
 
     def __init__(
         self,
-        storage: StorageBackend,
+        storage: Any,
         transaction_id: str | None = None,
         backup_dir: Path | None = None,
     ):
@@ -73,7 +83,7 @@ class Transaction:
 
         logger.info("Transaction started", transaction_id=self.transaction_id)
 
-    def _create_backup(self, key: str) -> DataObject | None:
+    def _create_backup(self, key: str) -> BackupSnapshot | None:
         """
         Create a backup of existing data.
 
@@ -86,8 +96,14 @@ class Transaction:
         try:
             if self.storage.exists(key):
                 data = self.storage.read(key)
+                metadata = None
+                if hasattr(self.storage, "get_metadata"):
+                    try:
+                        metadata = self.storage.get_metadata(key)
+                    except Exception:
+                        metadata = None
                 logger.debug("Created backup", key=key, transaction_id=self.transaction_id)
-                return data
+                return BackupSnapshot(key=key, data=data, metadata=metadata)
         except Exception as e:
             logger.warning(
                 "Failed to create backup",
@@ -96,6 +112,25 @@ class Transaction:
                 transaction_id=self.transaction_id,
             )
         return None
+
+    def _write_snapshot(self, snapshot: BackupSnapshot) -> None:
+        """Write a backup snapshot back to storage."""
+        if isinstance(snapshot.data, DataObject):
+            self.storage.write(snapshot.data)
+            return
+
+        custom_metadata: dict[str, Any] | None = None
+        if snapshot.metadata:
+            if isinstance(snapshot.metadata.get("custom"), dict):
+                custom_metadata = snapshot.metadata["custom"]
+            else:
+                custom_metadata = snapshot.metadata
+
+        try:
+            self.storage.write(snapshot.data, snapshot.key, custom_metadata)
+        except TypeError:
+            # Fallback for backends that only accept (data, key)
+            self.storage.write(snapshot.data, snapshot.key)
 
     def write(self, data: DataObject) -> str:
         """
@@ -132,6 +167,7 @@ class Transaction:
         try:
             # Write the DataObject directly (new API)
             result_key = self.storage.write(data)
+            operation.result_key = result_key
             logger.info(
                 "Transaction write completed",
                 key=result_key,
@@ -184,6 +220,7 @@ class Transaction:
             self.storage.delete(key)
             # Write the DataObject directly (new API)
             result_key = self.storage.write(data)
+            operation.result_key = result_key
             logger.info(
                 "Transaction update completed",
                 key=result_key,
@@ -295,10 +332,21 @@ class Transaction:
         for operation in reversed(self.operations):
             try:
                 if operation.operation_type in ("write", "update"):
+                    current_key = operation.result_key or operation.key
+
+                    # If update wrote to a different key, clean up the new key first.
+                    if (
+                        operation.operation_type == "update"
+                        and operation.result_key
+                        and operation.result_key != operation.key
+                        and self.storage.exists(operation.result_key)
+                    ):
+                        self.storage.delete(operation.result_key)
+
                     # Restore backup or delete if no backup
                     if operation.backup_data:
                         # Restore previous data
-                        self.storage.write(operation.backup_data)
+                        self._write_snapshot(operation.backup_data)
                         logger.debug(
                             "Restored backup",
                             key=operation.key,
@@ -306,17 +354,17 @@ class Transaction:
                         )
                     else:
                         # No backup means it was new, so delete it
-                        if self.storage.exists(operation.key):
-                            self.storage.delete(operation.key)
+                        if self.storage.exists(current_key):
+                            self.storage.delete(current_key)
                             logger.debug(
                                 "Deleted new data",
-                                key=operation.key,
+                                key=current_key,
                                 transaction_id=self.transaction_id,
                             )
 
                 elif operation.operation_type == "delete" and operation.backup_data:
                     # Restore deleted data
-                    self.storage.write(operation.backup_data)
+                    self._write_snapshot(operation.backup_data)
                     logger.debug(
                         "Restored deleted data",
                         key=operation.key,
@@ -368,7 +416,7 @@ class Transaction:
             logger.info(
                 "Exception in transaction, rolling back",
                 transaction_id=self.transaction_id,
-                exception=str(exc_val),
+                exception_message=str(exc_val),
             )
             try:
                 self.rollback()
@@ -387,7 +435,7 @@ class TransactionalStorage:
     Wrapper for storage backend that provides transaction support.
     """
 
-    def __init__(self, storage: StorageBackend):
+    def __init__(self, storage: Any):
         """
         Initialize transactional storage.
 
@@ -472,9 +520,9 @@ class TransactionalStorage:
             return self._current_transaction.delete(key)
         return self.storage.delete(key)
 
-    def read(self, key: str) -> DataObject:
+    def read(self, key: str, *args, **kwargs):
         """Read data from storage."""
-        return self.storage.read(key)
+        return self.storage.read(key, *args, **kwargs)
 
     def exists(self, key: str) -> bool:
         """Check if data exists."""
@@ -482,4 +530,10 @@ class TransactionalStorage:
 
     def list_keys(self, prefix: str = "") -> list[str]:
         """List storage keys."""
-        return self.storage.list_keys(prefix)
+        try:
+            return self.storage.list_keys(prefix)
+        except TypeError:
+            keys = self.storage.list_keys()
+            if prefix:
+                return [key for key in keys if key.startswith(prefix)]
+            return keys

--- a/tests/core/test_keys.py
+++ b/tests/core/test_keys.py
@@ -1,0 +1,50 @@
+"""Tests for canonical storage key helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from ml4t.data.core.keys import (
+    build_storage_key,
+    is_storage_key,
+    normalize_storage_key,
+    parse_storage_key,
+)
+
+
+def test_build_storage_key_defaults() -> None:
+    assert build_storage_key("AAPL") == "equities/daily/AAPL"
+
+
+def test_build_storage_key_custom_parts() -> None:
+    assert build_storage_key("BTC", asset_class="crypto", frequency="hourly") == "crypto/hourly/BTC"
+
+
+def test_build_storage_key_rejects_empty_parts() -> None:
+    with pytest.raises(ValueError, match="symbol cannot be empty"):
+        build_storage_key("")
+
+
+def test_is_storage_key() -> None:
+    assert is_storage_key("equities/daily/AAPL") is True
+    assert is_storage_key("AAPL") is False
+    assert is_storage_key("equities/daily/") is False
+
+
+def test_parse_storage_key() -> None:
+    assert parse_storage_key("equities/daily/AAPL") == ("equities", "daily", "AAPL")
+
+
+def test_parse_storage_key_rejects_invalid_format() -> None:
+    with pytest.raises(ValueError, match="invalid storage key format"):
+        parse_storage_key("AAPL")
+
+
+def test_normalize_storage_key_from_symbol() -> None:
+    assert normalize_storage_key("AAPL", asset_class="equities", frequency="daily") == (
+        "equities/daily/AAPL"
+    )
+
+
+def test_normalize_storage_key_from_key() -> None:
+    assert normalize_storage_key("crypto/hourly/BTC") == "crypto/hourly/BTC"

--- a/tests/test_async_storage.py
+++ b/tests/test_async_storage.py
@@ -432,50 +432,68 @@ class TestAsyncStorageAdapter:
         with tempfile.TemporaryDirectory() as tmpdir:
             async_backend = AsyncFileSystemBackend(data_root=Path(tmpdir))
             adapter = AsyncStorageAdapter(async_backend)
+            try:
+                # Write data (sync)
+                key = adapter.write(sample_data)
+                assert key == "equities/daily/TEST"
 
-            # Write data (sync)
-            key = adapter.write(sample_data)
-            assert key == "equities/daily/TEST"
-
-            # Read data (sync)
-            loaded_data = adapter.read(key)
-            assert loaded_data.metadata.symbol == "TEST"
-            assert len(loaded_data.data) == 3
+                # Read data (sync)
+                loaded_data = adapter.read(key)
+                assert loaded_data.metadata.symbol == "TEST"
+                assert len(loaded_data.data) == 3
+            finally:
+                adapter.close()
 
     def test_adapter_exists_delete(self, sample_data):
         """Test adapter exists and delete in sync context."""
         with tempfile.TemporaryDirectory() as tmpdir:
             async_backend = AsyncFileSystemBackend(data_root=Path(tmpdir))
             adapter = AsyncStorageAdapter(async_backend)
+            try:
+                key = "equities/daily/TEST"
 
-            key = "equities/daily/TEST"
+                # Check exists
+                assert not adapter.exists(key)
 
-            # Check exists
-            assert not adapter.exists(key)
+                # Write data
+                adapter.write(sample_data)
+                assert adapter.exists(key)
 
-            # Write data
-            adapter.write(sample_data)
-            assert adapter.exists(key)
-
-            # Delete data
-            adapter.delete(key)
-            assert not adapter.exists(key)
+                # Delete data
+                adapter.delete(key)
+                assert not adapter.exists(key)
+            finally:
+                adapter.close()
 
     def test_adapter_list_keys(self, sample_data, sample_data_2):
         """Test adapter list_keys in sync context."""
         with tempfile.TemporaryDirectory() as tmpdir:
             async_backend = AsyncFileSystemBackend(data_root=Path(tmpdir))
             adapter = AsyncStorageAdapter(async_backend)
+            try:
+                # Write data
+                adapter.write(sample_data)
+                adapter.write(sample_data_2)
 
-            # Write data
-            adapter.write(sample_data)
-            adapter.write(sample_data_2)
+                # List keys
+                keys = adapter.list_keys()
+                assert len(keys) == 2
+                assert "equities/daily/TEST" in keys
+                assert "equities/daily/TEST2" in keys
+            finally:
+                adapter.close()
 
-            # List keys
-            keys = adapter.list_keys()
-            assert len(keys) == 2
-            assert "equities/daily/TEST" in keys
-            assert "equities/daily/TEST2" in keys
+    @pytest.mark.asyncio
+    async def test_adapter_raises_inside_running_loop(self, sample_data):
+        """Sync adapter should not be used from inside an active event loop."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            async_backend = AsyncFileSystemBackend(data_root=Path(tmpdir))
+            adapter = AsyncStorageAdapter(async_backend)
+            try:
+                with pytest.raises(RuntimeError, match="cannot run inside an active event loop"):
+                    adapter.write(sample_data)
+            finally:
+                adapter.close()
 
 
 class TestFactoryFunctions:
@@ -505,6 +523,9 @@ class TestFactoryFunctions:
 
             assert isinstance(adapter, AsyncStorageAdapter)
 
-            # Test it works
-            key = adapter.write(sample_data)
-            assert adapter.exists(key)
+            try:
+                # Test it works
+                key = adapter.write(sample_data)
+                assert adapter.exists(key)
+            finally:
+                adapter.close()

--- a/tests/test_cli_interface.py
+++ b/tests/test_cli_interface.py
@@ -12,6 +12,7 @@ import pytest
 from click.testing import CliRunner
 
 from ml4t.data.cli_interface import cli
+from ml4t.data.storage.key_codec import encode_storage_key
 
 
 class TestCLIBasics:
@@ -216,7 +217,6 @@ class TestUpdateCommand:
     @patch("ml4t.data.cli.core.MetadataTracker")
     @patch("ml4t.data.cli.core.IncrementalUpdater")
     @patch("ml4t.data.cli.core.DataManager")
-    @pytest.mark.skip(reason="CLI mock/config issues in PRE-RELEASE")
     def test_update_incremental(
         self, mock_dm_class, mock_updater_class, mock_tracker_class, mock_storage_class
     ):
@@ -247,6 +247,7 @@ class TestUpdateCommand:
         mock_result.success = True
         mock_result.rows_added = 5
         mock_result.rows_updated = 0
+        mock_result.gaps_filled = 0
         mock_updater.update_incremental.return_value = mock_result
 
         runner = CliRunner()
@@ -305,6 +306,49 @@ class TestUpdateCommand:
 
             assert result.exit_code == 0
             assert "Data already up to date" in result.output
+            mock_updater.determine_update_range.assert_called_once()
+            args = mock_updater.determine_update_range.call_args[0]
+            assert args[1] == "equities/daily/BTC"
+
+    @patch("ml4t.data.cli.core.HiveStorage")
+    @patch("ml4t.data.cli.core.MetadataTracker")
+    @patch("ml4t.data.cli.core.IncrementalUpdater")
+    def test_update_preserves_explicit_storage_key(
+        self, mock_updater_class, mock_tracker_class, mock_storage_class
+    ):
+        """Test update uses explicit key when canonical key is passed."""
+        mock_updater = MagicMock()
+        mock_updater_class.return_value = mock_updater
+        mock_storage = MagicMock()
+        mock_storage_class.return_value = mock_storage
+        mock_tracker = MagicMock()
+        mock_tracker_class.return_value = mock_tracker
+
+        mock_updater.determine_update_range.return_value = (
+            datetime(2024, 1, 10),
+            datetime(2024, 1, 10),
+            "none",
+        )
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(
+                cli,
+                [
+                    "update",
+                    "--symbol",
+                    "crypto/hourly/BTC",
+                    "--start",
+                    "2024-01-01",
+                    "--end",
+                    "2024-01-10",
+                ],
+            )
+
+            assert result.exit_code == 0
+            mock_updater.determine_update_range.assert_called_once()
+            args = mock_updater.determine_update_range.call_args[0]
+            assert args[1] == "crypto/hourly/BTC"
 
 
 class TestValidateCommand:
@@ -422,7 +466,6 @@ class TestStatusCommand:
 
     @patch("ml4t.data.cli.core.MetadataTracker")
     @patch("ml4t.data.cli.core.HiveStorage")
-    @pytest.mark.skip(reason="CLI mock/config issues in PRE-RELEASE")
     def test_status_detailed(self, mock_storage_class, mock_tracker_class):
         """Test detailed status with --detailed flag."""
         mock_storage = MagicMock()
@@ -430,6 +473,15 @@ class TestStatusCommand:
         mock_tracker = MagicMock()
         mock_tracker_class.return_value = mock_tracker
 
+        mock_tracker.get_summary.return_value = {
+            "total_datasets": 1,
+            "healthy": 1,
+            "stale": 0,
+            "error": 0,
+            "total_rows": 10,
+            "total_updates": 1,
+            "by_asset_class": {"crypto": 1},
+        }
         mock_storage.list_keys.return_value = ["BTC"]
 
         # Mock detailed metadata
@@ -497,13 +549,12 @@ class TestBatchOperations:
             assert "Fetching 2 symbols from file" in result.output
 
     @patch("ml4t.data.cli.core.DataManager")
-    @pytest.mark.skip(reason="CLI mock/config issues in PRE-RELEASE")
     def test_fetch_with_config(self, mock_dm_class):
         """Test fetching with configuration file."""
         mock_dm = MagicMock()
         mock_dm_class.return_value = mock_dm
         mock_df = pl.DataFrame({"timestamp": [datetime(2024, 1, 1)]})
-        mock_dm.fetch.return_value = mock_df
+        mock_dm.fetch_batch.return_value = {"BTC": mock_df, "ETH": mock_df}
 
         runner = CliRunner()
         with runner.isolated_filesystem():
@@ -524,11 +575,18 @@ class TestBatchOperations:
                     "fetch",
                     "--config",
                     "config.json",
+                    "--start",
+                    "2020-01-01",
+                    "--end",
+                    "2020-01-31",
                 ],
             )
 
             assert result.exit_code == 0
             assert "Loading configuration from config.json" in result.output
+            mock_dm.fetch_batch.assert_called_once_with(
+                ["BTC", "ETH"], "2024-01-01", "2024-01-31", frequency="hourly"
+            )
 
 
 class TestProgressAndOutput:
@@ -573,37 +631,33 @@ class TestProgressAndOutput:
         # Progress indicators should be in output
         assert "Fetching 5 symbols" in result.output
 
-    @pytest.mark.skip(reason="CLI mock/config issues in PRE-RELEASE")
     def test_quiet_mode(self):
         """Test quiet mode suppresses output."""
         runner = CliRunner()
-        result = runner.invoke(cli, ["status", "--quiet"])
+        result = runner.invoke(cli, ["--quiet", "status"])
         assert result.exit_code == 0
         # Only essential output, no decorative elements
         assert "═" not in result.output  # No box drawing
 
-    @pytest.mark.skip(reason="Verbose output format is implementation-specific")
     def test_verbose_mode(self):
         """Test verbose mode shows detailed information."""
         runner = CliRunner()
         result = runner.invoke(cli, ["--verbose", "status"])
         assert result.exit_code == 0
-        # Should show debug information
-        assert "Configuration" in result.output or "Debug" in result.output
+        assert "Storage path:" in result.output
 
 
 class TestShellCompletion:
     """Test shell completion support."""
 
-    @pytest.mark.skip(reason="CLI mock/config issues in PRE-RELEASE")
     def test_completion_installation(self):
         """Test shell completion installation command."""
         runner = CliRunner()
 
         # Test bash completion
-        result = runner.invoke(cli, ["--show-completion", "bash"])
+        result = runner.invoke(cli, ["show-completion", "bash"])
         assert result.exit_code == 0
-        assert "_QDATA_COMPLETE" in result.output
+        assert "_ML4T_DATA_COMPLETE" in result.output
 
     def test_completion_symbols(self):
         """Test symbol completion suggestions."""
@@ -1361,6 +1415,45 @@ datasets: {}
 
         # Should not crash
         assert result.exit_code == 0
+
+    def test_list_reads_top_level_manifest_fields(self):
+        """Test list command can parse manifests without custom payload."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            storage_path = Path("data")
+            metadata_dir = storage_path / ".metadata"
+            metadata_dir.mkdir(parents=True)
+
+            key = "futures/daily/ESZ4"
+            metadata_file = metadata_dir / f"{encode_storage_key(key)}.json"
+            metadata_file.write_text(
+                json.dumps(
+                    {
+                        "provider": "databento",
+                        "symbol": "ESZ4",
+                        "row_count": 15,
+                        "data_range": {
+                            "start": "2024-01-01T00:00:00",
+                            "end": "2024-01-15T00:00:00",
+                        },
+                        "last_update": "2024-01-15T12:00:00",
+                    }
+                )
+            )
+
+            Path("config.yaml").write_text(
+                """
+storage:
+  path: data
+datasets: {}
+"""
+            )
+
+            result = runner.invoke(cli, ["list", "-c", "config.yaml"])
+
+        assert result.exit_code == 0
+        assert "Futures (DataBento)" in result.output
+        assert "ESZ4" in result.output
 
 
 class TestDownloadFuturesCommand:

--- a/tests/test_data_manager_storage.py
+++ b/tests/test_data_manager_storage.py
@@ -771,9 +771,9 @@ class TestDataManagerListSymbols:
         mock_fetch.return_value = sample_data
 
         # Load multiple symbols
-        manager.load("AAPL", "2024-01-01", "2024-01-05", provider="yahoo")
-        manager.load("MSFT", "2024-01-01", "2024-01-05", provider="yahoo")
-        manager.load("GOOGL", "2024-01-01", "2024-01-05", provider="yahoo")
+        manager.load("AAPL", "2024-01-01", "2024-01-05", provider="mock")
+        manager.load("MSFT", "2024-01-01", "2024-01-05", provider="mock")
+        manager.load("GOOGL", "2024-01-01", "2024-01-05", provider="mock")
 
         symbols = manager.list_symbols()
 
@@ -787,10 +787,10 @@ class TestDataManagerListSymbols:
         mock_fetch.return_value = sample_data
 
         # Load from different providers
-        manager.load("AAPL", "2024-01-01", "2024-01-05", provider="yahoo")
+        manager.load("AAPL", "2024-01-01", "2024-01-05", provider="mock")
 
         # Filter by provider
-        symbols = manager.list_symbols(provider="yahoo")
+        symbols = manager.list_symbols(provider="mock")
 
         assert isinstance(symbols, list)
 

--- a/tests/test_fama_french_provider.py
+++ b/tests/test_fama_french_provider.py
@@ -290,7 +290,6 @@ class TestFetch:
             assert len(df) == 1
             assert df["Mkt-RF"][0] == 0.01
 
-    @pytest.mark.xfail(reason="Provider date filtering has type mismatch bug")
     def test_fetch_date_filtering(self):
         """Test fetch with start/end date filtering."""
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_hive_storage.py
+++ b/tests/test_hive_storage.py
@@ -8,6 +8,7 @@ import pytest
 
 from ml4t.data.storage.backend import StorageConfig
 from ml4t.data.storage.hive import HiveStorage
+from ml4t.data.storage.key_codec import encode_storage_key
 
 
 class TestHiveStorageInit:
@@ -102,7 +103,7 @@ class TestHiveStorageWrite:
 
         storage.write(df, "test_key")
 
-        metadata_file = storage.metadata_dir / "test_key.json"
+        metadata_file = storage.metadata_dir / f"{encode_storage_key('test_key')}.json"
         assert metadata_file.exists()
 
         with open(metadata_file) as f:
@@ -384,7 +385,7 @@ class TestHiveStorageIncrementalMethods:
     def test_get_combined_file_path(self, storage):
         """Test getting combined file path."""
         path = storage.get_combined_file_path("AAPL", "yahoo")
-        assert "yahoo_AAPL" in str(path)
+        assert path.name == encode_storage_key("yahoo/AAPL")
 
     def test_read_data_no_data(self, storage):
         """Test reading data when no data exists."""
@@ -454,7 +455,7 @@ class TestHiveStorageSlashInKey:
     """Tests for keys with slashes (hierarchy)."""
 
     def test_write_with_slash_key(self, tmp_path):
-        """Test writing with slash in key converts to underscore."""
+        """Test writing with slash in key uses encoded directory names."""
         config = StorageConfig(base_path=tmp_path)
         storage = HiveStorage(config)
 
@@ -466,8 +467,7 @@ class TestHiveStorageSlashInKey:
         )
         storage.write(df, "provider/symbol")
 
-        # Directory name should use underscore
-        assert (tmp_path / "provider_symbol").exists()
+        assert (tmp_path / encode_storage_key("provider/symbol")).exists()
 
     def test_exists_with_slash_key(self, tmp_path):
         """Test exists handles slash in key."""

--- a/tests/test_incremental_update_system.py
+++ b/tests/test_incremental_update_system.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import polars as pl
-import pytest
 
 from ml4t.data.storage.backend import StorageConfig
 from ml4t.data.storage.hive import HiveStorage
@@ -366,6 +365,60 @@ class TestIncrementalUpdater:
             final_metadata = tracker.get_metadata("test_symbol")
             assert final_metadata == initial_metadata
 
+    def test_incremental_update_idempotent_on_repeated_input(self):
+        """Applying the same incremental payload twice should not duplicate rows."""
+        updater = IncrementalUpdater()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            storage = HiveStorage(StorageConfig(base_path=Path(tmpdir)))
+            tracker = MetadataTracker(Path(tmpdir))
+            key = "equities/daily/AAPL"
+
+            initial_dates = pl.date_range(
+                datetime(2024, 1, 1),
+                datetime(2024, 1, 10),
+                interval="1d",
+                eager=True,
+            )
+            initial = pl.DataFrame(
+                {
+                    "timestamp": initial_dates,
+                    "open": [100.0] * len(initial_dates),
+                    "close": [101.0] * len(initial_dates),
+                }
+            )
+            storage.write(initial, key)
+
+            incoming_dates = pl.date_range(
+                datetime(2024, 1, 8),
+                datetime(2024, 1, 15),
+                interval="1d",
+                eager=True,
+            )
+            incoming = pl.DataFrame(
+                {
+                    "timestamp": incoming_dates,
+                    "open": [102.0] * len(incoming_dates),
+                    "close": [103.0] * len(incoming_dates),
+                }
+            )
+
+            first = updater.update_incremental(storage, tracker, key, incoming, provider="test")
+            second = updater.update_incremental(storage, tracker, key, incoming, provider="test")
+
+            assert first.success is True
+            assert second.success is True
+            assert second.rows_added == 0
+
+            final_df = storage.read(key).collect()
+            assert len(final_df) == 15
+            assert len(final_df["timestamp"].unique()) == 15
+
+            metadata = tracker.get_metadata(key)
+            assert metadata is not None
+            assert metadata.total_rows == 15
+            assert metadata.update_count == 2
+
 
 class TestUpdateStrategy:
     """Tests for different update strategies."""
@@ -523,7 +576,6 @@ class TestUpdateStrategy:
 class TestBackfillManager:
     """Tests for backfill operations."""
 
-    @pytest.mark.skip(reason="Weekend exclusion logic makes gap detection complex for testing")
     def test_identify_backfill_candidates(self):
         """Test identification of datasets needing backfill."""
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -558,7 +610,7 @@ class TestBackfillManager:
             storage.write(df3, "no_gap")
 
             # Identify candidates
-            candidates = backfill_mgr.identify_candidates(min_gap_days=3)
+            candidates = backfill_mgr.identify_candidates(min_gap_days=3, max_age_days=5000)
 
             assert len(candidates) == 1
             assert candidates[0]["symbol"] == "large_gap"
@@ -657,9 +709,8 @@ class TestBackfillManager:
 class TestPerformanceOptimization:
     """Tests for performance optimization and validation."""
 
-    @pytest.mark.skip(reason="Timing-based performance tests are flaky - use benchmarks instead")
     def test_incremental_update_performance(self):
-        """Test that incremental updates are faster than full refresh."""
+        """Test incremental and full refresh update behavior."""
         with tempfile.TemporaryDirectory() as tmpdir:
             storage = HiveStorage(StorageConfig(base_path=Path(tmpdir)))
             tracker = MetadataTracker(Path(tmpdir))
@@ -694,10 +745,6 @@ class TestPerformanceOptimization:
                 }
             )
 
-            # Time incremental update
-            import time
-
-            start_time = time.time()
             result_incremental = updater.update_incremental(
                 storage,
                 tracker,
@@ -706,10 +753,7 @@ class TestPerformanceOptimization:
                 provider="test",
                 strategy=UpdateStrategy.INCREMENTAL,
             )
-            incremental_time = time.time() - start_time
 
-            # Time full refresh
-            start_time = time.time()
             result_full = updater.update_incremental(
                 storage,
                 tracker,
@@ -718,13 +762,12 @@ class TestPerformanceOptimization:
                 provider="test",
                 strategy=UpdateStrategy.FULL_REFRESH,
             )
-            full_refresh_time = time.time() - start_time
 
-            # Incremental should generally be faster (or at least not significantly slower)
-            # With small datasets, the timing can be variable due to system overhead
-            assert incremental_time <= full_refresh_time * 1.5  # Allow some variance for small data
             assert result_incremental.success is True
             assert result_full.success is True
+            assert result_incremental.rows_added == len(df_new)
+            assert result_incremental.rows_updated == 0
+            assert result_full.rows_after == len(df_initial) + len(df_new)
 
     def test_download_reduction_metric(self):
         """Test that incremental updates reduce download size by 80%."""

--- a/tests/test_metadata_manager.py
+++ b/tests/test_metadata_manager.py
@@ -1,0 +1,89 @@
+"""Tests for metadata manager normalization and fallback behavior."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ml4t.data.managers.metadata_manager import MetadataManager
+from ml4t.data.storage.key_codec import encode_storage_key
+
+
+class _StorageWithGetMetadata:
+    """Simple storage stub exposing get_metadata only."""
+
+    def __init__(self, metadata: dict) -> None:
+        self._metadata = metadata
+
+    def get_metadata(self, _key: str) -> dict:
+        return self._metadata
+
+
+class _StorageWithMetadataDir:
+    """Simple storage stub exposing metadata_dir only."""
+
+    def __init__(self, metadata_dir: Path) -> None:
+        self.metadata_dir = metadata_dir
+
+
+def test_get_metadata_for_key_normalizes_manifest_shape() -> None:
+    """MetadataManager should expose canonical fields from manifest custom payload."""
+    manager = MetadataManager(
+        _StorageWithGetMetadata(
+            {
+                "row_count": 25,
+                "custom": {
+                    "provider": "yahoo",
+                    "symbol": "AAPL",
+                    "asset_class": "equities",
+                    "frequency": "daily",
+                    "start_date": "2024-01-01T00:00:00",
+                    "end_date": "2024-01-31T00:00:00",
+                },
+            }
+        )
+    )
+
+    metadata = manager.get_metadata_for_key("equities/daily/AAPL")
+    assert metadata is not None
+    assert metadata["provider"] == "yahoo"
+    assert metadata["symbol"] == "AAPL"
+    assert metadata["asset_class"] == "equities"
+    assert metadata["frequency"] == "daily"
+    assert metadata["total_rows"] == 25
+    assert metadata["data_range"] == {
+        "start": "2024-01-01T00:00:00",
+        "end": "2024-01-31T00:00:00",
+    }
+
+
+def test_get_metadata_for_key_reads_encoded_metadata_file(tmp_path: Path) -> None:
+    """MetadataManager should read encoded metadata filenames when storage API is absent."""
+    metadata_dir = tmp_path / ".metadata"
+    metadata_dir.mkdir()
+
+    key = "crypto/hourly/BTCUSD"
+    metadata_file = metadata_dir / f"{encode_storage_key(key)}.json"
+    metadata_file.write_text(
+        json.dumps(
+            {
+                "row_count": 10,
+                "custom": {
+                    "provider": "cryptocompare",
+                    "symbol": "BTCUSD",
+                    "asset_class": "crypto",
+                    "frequency": "hourly",
+                },
+            }
+        )
+    )
+
+    manager = MetadataManager(_StorageWithMetadataDir(metadata_dir))
+    metadata = manager.get_metadata_for_key(key)
+
+    assert metadata is not None
+    assert metadata["provider"] == "cryptocompare"
+    assert metadata["symbol"] == "BTCUSD"
+    assert metadata["asset_class"] == "crypto"
+    assert metadata["frequency"] == "hourly"
+    assert metadata["total_rows"] == 10

--- a/tests/test_metadata_tracker.py
+++ b/tests/test_metadata_tracker.py
@@ -3,6 +3,7 @@
 from datetime import datetime, timedelta
 from pathlib import Path
 
+from ml4t.data.storage.key_codec import encode_storage_key
 from ml4t.data.storage.metadata_tracker import (
     DatasetMetadata,
     MetadataTracker,
@@ -393,3 +394,64 @@ class TestMetadataTracker:
         status, message = tracker.check_health(key)
         assert status == "error"
         assert "errors in last 5 updates" in message
+
+    def test_get_metadata_from_storage_manifest(self, tmp_path: Path) -> None:
+        """Test manifest metadata is converted to DatasetMetadata."""
+        tracker = MetadataTracker(base_path=tmp_path)
+        key = "equities/daily/AAPL"
+        manifest_path = tracker.metadata_dir / f"{encode_storage_key(key)}.json"
+
+        manifest_path.write_text(
+            """{
+  "last_updated": "2024-01-15T00:00:00",
+  "row_count": 123,
+  "custom": {
+    "provider": "yahoo",
+    "symbol": "AAPL",
+    "asset_class": "equities",
+    "frequency": "daily",
+    "start_date": "2024-01-01T00:00:00",
+    "end_date": "2024-01-15T00:00:00"
+  }
+}"""
+        )
+
+        metadata = tracker.get_metadata(key)
+        assert metadata is not None
+        assert metadata.symbol == "AAPL"
+        assert metadata.provider == "yahoo"
+        assert metadata.asset_class == "equities"
+        assert metadata.frequency == "daily"
+        assert metadata.total_rows == 123
+
+    def test_summary_and_updates_include_manifest_metadata(self, tmp_path: Path) -> None:
+        """Test summary and list_updates include manifest-only datasets."""
+        tracker = MetadataTracker(base_path=tmp_path)
+        key = "futures/daily/ESZ4"
+        manifest_path = tracker.metadata_dir / f"{encode_storage_key(key)}.json"
+
+        manifest_path.write_text(
+            """{
+  "provider": "databento",
+  "symbol": "ESZ4",
+  "last_update": "2024-02-01T00:00:00",
+  "row_count": 42,
+  "data_range": {
+    "start": "2024-01-01T00:00:00",
+    "end": "2024-02-01T00:00:00"
+  }
+}"""
+        )
+
+        summary = tracker.get_summary()
+        assert summary["total_datasets"] == 1
+        assert summary["total_rows"] == 42
+        assert summary["unique_providers"] == 1
+        assert summary["unique_symbols"] == 1
+
+        updates = tracker.list_updates()
+        assert len(updates) == 1
+        assert updates[0].symbol == "ESZ4"
+        assert updates[0].provider == "databento"
+        assert updates[0].asset_class == "futures"
+        assert updates[0].frequency == "daily"

--- a/tests/test_multi_asset.py
+++ b/tests/test_multi_asset.py
@@ -264,57 +264,53 @@ class TestMultiAssetWorkflows:
 class TestPerformanceIntegration:
     """Test performance characteristics across integrated features."""
 
-    @pytest.mark.skip(reason="Performance targets not finalized")
-    def test_batch_load_universe_performance_target(self):
-        """Validate loading 10 symbols completes in reasonable time.
-
-        This tests real-world performance with network fetching and rate limiting.
-        Yahoo Finance has rate limiting (~2s between requests with max_workers=4),
-        so 10 symbols will take ~20-30s. This is expected and acceptable.
-
-        The key validation is that:
-        1. All symbols fetch successfully
-        2. Multi-asset schema is correct
-        3. Parallel fetching works (not sequential)
-        """
+    def test_batch_load_universe_performance_target(self, monkeypatch):
+        """Validate mocked universe batch-load completes within deterministic budget."""
         # Create small custom universe
         test_symbols = ["AAPL", "MSFT", "GOOGL", "AMZN", "META", "TSLA", "NVDA", "JPM", "V", "WMT"]
         Universe.add_custom("test_perf_10", test_symbols)
 
         try:
             manager = DataManager(output_format="polars")
+            base_time = datetime(2024, 1, 1, tzinfo=UTC)
+
+            def mock_fetch(symbol, start, end, frequency="daily", provider=None, **kwargs):
+                _ = (start, end, frequency, provider, kwargs)
+                return pl.DataFrame(
+                    {
+                        "timestamp": [base_time, base_time + timedelta(days=1)],
+                        "open": [100.0, 101.0],
+                        "high": [101.0, 102.0],
+                        "low": [99.0, 100.0],
+                        "close": [100.5, 101.5],
+                        "volume": [1_000_000.0, 1_100_000.0],
+                    }
+                )
+
+            monkeypatch.setattr(manager._batch_manager.fetch_manager, "fetch", mock_fetch)
 
             # Time the operation
             start_time = time.perf_counter()
 
-            # This fetches from Yahoo Finance with rate limiting
-            # We test with a very small date range to be respectful to providers
             df = manager.batch_load_universe(
                 universe="test_perf_10",
                 start="2024-01-01",
-                end="2024-01-05",  # Just 5 days
+                end="2024-01-05",
                 provider="yahoo",
-                fail_on_partial=False,  # Graceful degradation
+                fail_on_partial=False,
             )
 
             elapsed = time.perf_counter() - start_time
 
-            # Verify we got data for all symbols
+            # Verify all symbols are present and schema is valid
             assert len(df) > 0
             assert "symbol" in df.columns
             assert MultiAssetSchema.validate(df, strict=True)
-
-            # Should get data for most/all symbols
             unique_symbols = df["symbol"].n_unique()
-            assert unique_symbols >= 8, f"Expected at least 8 symbols, got {unique_symbols}"
+            assert unique_symbols == 10, f"Expected 10 symbols, got {unique_symbols}"
 
-            # Performance expectation: with rate limiting, this will take 20-30s
-            # This is acceptable for network fetching with proper rate limiting
-            print(f"\n✓ Loaded {unique_symbols} symbols in {elapsed:.3f}s")
-            print(f"  (Rate-limited network fetch: ~{elapsed / unique_symbols:.1f}s per symbol)")
-
-            # Sanity check: should complete in < 60s (very conservative)
-            assert elapsed < 60.0, f"Expected <60s, got {elapsed:.3f}s"
+            # Deterministic budget for mocked I/O path in CI
+            assert elapsed < 2.0, f"Expected <2s, got {elapsed:.3f}s"
 
         finally:
             Universe.remove_custom("test_perf_10")
@@ -596,15 +592,32 @@ class TestErrorHandling:
                 fetch_missing=False,
             )
 
-    @pytest.mark.skip(reason="Error handling not implemented")
-    def test_partial_failures_with_graceful_degradation(self):
-        """Test that partial failures can be handled gracefully."""
+    def test_partial_failures_with_graceful_degradation(self, monkeypatch):
+        """Test graceful handling when some symbols fail in batch fetch."""
         manager = DataManager(output_format="polars")
+        base_time = datetime(2024, 1, 1, tzinfo=UTC)
+
+        def mock_fetch(symbol, start, end, frequency="daily", provider=None, **kwargs):
+            _ = (start, end, frequency, provider, kwargs)
+            if symbol == "INVALID_SYMBOL_123":
+                raise ValueError("symbol not found")
+            return pl.DataFrame(
+                {
+                    "timestamp": [base_time, base_time + timedelta(days=1)],
+                    "open": [100.0, 101.0],
+                    "high": [101.0, 102.0],
+                    "low": [99.0, 100.0],
+                    "close": [100.5, 101.5],
+                    "volume": [1_000_000.0, 1_100_000.0],
+                }
+            )
+
+        monkeypatch.setattr(manager._batch_manager.fetch_manager, "fetch", mock_fetch)
 
         # Mix of valid and invalid symbols
         symbols = ["AAPL", "INVALID_SYMBOL_123", "MSFT"]
 
-        # With fail_on_partial=False, should get data for valid symbols
+        # With fail_on_partial=False, only valid symbols should be returned
         df = manager.batch_load(
             symbols=symbols,
             start="2024-01-01",
@@ -613,13 +626,24 @@ class TestErrorHandling:
             fail_on_partial=False,
         )
 
-        # Should have data for at least one valid symbol
+        # Verify partial success behavior
         unique_symbols = df["symbol"].unique().to_list()
-        assert "AAPL" in unique_symbols or "MSFT" in unique_symbols
+        assert "AAPL" in unique_symbols
+        assert "MSFT" in unique_symbols
         assert "INVALID_SYMBOL_123" not in unique_symbols
 
-        # Should still be valid multi-asset format
+        # Should still satisfy multi-asset invariants
         assert MultiAssetSchema.validate(df, strict=True)
+
+        # fail_on_partial=True should raise on same input
+        with pytest.raises(ValueError, match="Batch load failed for 1 symbols"):
+            manager.batch_load(
+                symbols=symbols,
+                start="2024-01-01",
+                end="2024-01-05",
+                provider="yahoo",
+                fail_on_partial=True,
+            )
 
     def test_format_conversion_with_missing_data(self):
         """Test format conversion handles missing data gracefully."""

--- a/tests/test_storage_backends.py
+++ b/tests/test_storage_backends.py
@@ -1,5 +1,6 @@
 """Tests for ML4T Data Hive and Flat storage backends."""
 
+import json
 import shutil
 import tempfile
 from datetime import datetime, timedelta
@@ -15,6 +16,7 @@ from ml4t.data.storage import (
     StorageConfig,
     create_storage,
 )
+from ml4t.data.storage.key_codec import encode_storage_key
 
 
 @pytest.fixture
@@ -106,6 +108,38 @@ class TestStorageBackends:
         assert metadata["custom"]["source"] == "test"
 
     @pytest.mark.parametrize("strategy", ["hive", "flat"])
+    def test_get_metadata_auto_upgrades_legacy_manifest(self, temp_dir, strategy):
+        """Reading legacy manifests should upgrade and persist manifest_version=1.0."""
+        storage = create_storage(temp_dir, strategy=strategy)
+        key = "equities/daily/AAPL"
+        metadata_file = storage.metadata_dir / f"{encode_storage_key(key)}.json"
+        metadata_file.write_text(
+            json.dumps(
+                {
+                    "row_count": 3,
+                    "custom": {"provider": "yahoo"},
+                    "data_range": {
+                        "start": "2024-01-01T00:00:00",
+                        "end": "2024-01-03T00:00:00",
+                    },
+                }
+            )
+        )
+
+        with pytest.deprecated_call(match="without 'manifest_version'"):
+            metadata = storage.get_metadata(key)
+
+        assert metadata is not None
+        assert metadata["manifest_version"] == "1.0"
+        assert metadata["provider"] == "yahoo"
+        assert metadata["symbol"] == "AAPL"
+        assert metadata["asset_class"] == "equities"
+        assert metadata["frequency"] == "daily"
+
+        persisted = json.loads(metadata_file.read_text())
+        assert persisted["manifest_version"] == "1.0"
+
+    @pytest.mark.parametrize("strategy", ["hive", "flat"])
     def test_list_keys(self, temp_dir, sample_data, strategy):
         """Test listing stored keys."""
         storage = create_storage(temp_dir, strategy=strategy)
@@ -152,7 +186,7 @@ class TestStorageBackends:
         storage.write(sample_data.lazy(), "test_key")
 
         # Check partition structure
-        key_path = temp_dir / "test_key"
+        key_path = temp_dir / encode_storage_key("test_key")
         assert key_path.exists()
 
         # Should have year directories
@@ -175,6 +209,50 @@ class TestStorageBackends:
         # No temp files should remain
         temp_files = list(temp_dir.glob("*.tmp"))
         assert len(temp_files) == 0
+
+    @pytest.mark.parametrize("strategy", ["hive", "flat"])
+    def test_atomic_write_cleans_temp_file_on_failure(
+        self, temp_dir, sample_data, strategy, monkeypatch
+    ):
+        """Atomic write should clean parquet temp files when write fails."""
+        storage = create_storage(temp_dir, strategy=strategy)
+
+        def raise_write_error(_self, *_args, **_kwargs):
+            raise RuntimeError("simulated parquet write failure")
+
+        monkeypatch.setattr(pl.DataFrame, "write_parquet", raise_write_error)
+
+        with pytest.raises(RuntimeError, match="simulated parquet write failure"):
+            storage.write(sample_data.lazy(), "test_key")
+
+        assert list(temp_dir.rglob("*.parquet.tmp")) == []
+
+    @pytest.mark.parametrize("strategy", ["hive", "flat"])
+    def test_metadata_write_preserves_existing_file_on_failure(
+        self, temp_dir, sample_data, strategy, monkeypatch
+    ):
+        """Metadata writes should be crash-safe and not corrupt existing manifest."""
+        storage = create_storage(temp_dir, strategy=strategy)
+        storage.write(sample_data.lazy(), "test_key")
+        original = storage.get_metadata("test_key")
+        assert original is not None
+
+        if strategy == "hive":
+            import ml4t.data.storage.hive as storage_module
+        else:
+            import ml4t.data.storage.flat as storage_module
+
+        def raise_json_error(*_args, **_kwargs):
+            raise RuntimeError("simulated metadata write failure")
+
+        monkeypatch.setattr(storage_module.json, "dump", raise_json_error)
+
+        with pytest.raises(RuntimeError, match="simulated metadata write failure"):
+            storage._update_metadata("test_key", {"row_count": 999})
+
+        restored = storage.get_metadata("test_key")
+        assert restored == original
+        assert list((temp_dir / ".metadata").glob("*.json.tmp")) == []
 
     def test_lazy_evaluation(self, temp_dir, sample_data):
         """Test that lazy evaluation is preserved."""

--- a/tests/test_storage_key_codec.py
+++ b/tests/test_storage_key_codec.py
@@ -1,0 +1,26 @@
+"""Tests for storage key codec helpers."""
+
+from ml4t.data.storage.key_codec import (
+    decode_storage_key,
+    encode_storage_key,
+    is_encoded_storage_key,
+)
+
+
+def test_encode_decode_roundtrip() -> None:
+    """Encoding should be reversible for storage keys."""
+    key = "equities/daily/BRK_B"
+    encoded = encode_storage_key(key)
+
+    assert is_encoded_storage_key(encoded)
+    assert decode_storage_key(encoded) == key
+
+
+def test_decode_legacy_underscore_name() -> None:
+    """Legacy underscore names should still decode to slash-separated keys."""
+    assert decode_storage_key("provider_symbol") == "provider/symbol"
+
+
+def test_encoded_prefix() -> None:
+    """Encoded values should be prefixed for easy detection."""
+    assert encode_storage_key("x/y").startswith("k__")

--- a/tests/test_storage_manifest.py
+++ b/tests/test_storage_manifest.py
@@ -1,0 +1,129 @@
+"""Tests for canonical storage metadata manifest contract."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from ml4t.data.storage.manifest import (
+    MANIFEST_VERSION,
+    ManifestV1,
+    manifest_from_write,
+    manifest_with_incremental_update,
+    normalize_manifest_payload,
+    upgrade_manifest_payload,
+)
+
+
+def test_manifest_v1_from_payload_backfills_key_components() -> None:
+    """Manifest parser should derive symbol/asset_class/frequency from storage key."""
+    manifest = ManifestV1.from_payload(
+        "equities/daily/AAPL",
+        {
+            "row_count": 25,
+            "custom": {
+                "provider": "yahoo",
+                "start_date": "2024-01-01T00:00:00",
+                "end_date": "2024-01-31T00:00:00",
+            },
+        },
+    )
+
+    assert manifest.manifest_version == MANIFEST_VERSION
+    assert manifest.key == "equities/daily/AAPL"
+    assert manifest.provider == "yahoo"
+    assert manifest.symbol == "AAPL"
+    assert manifest.asset_class == "equities"
+    assert manifest.frequency == "daily"
+    assert manifest.row_count == 25
+    assert manifest.data_range["start"] == "2024-01-01T00:00:00"
+    assert manifest.data_range["end"] == "2024-01-31T00:00:00"
+
+
+def test_manifest_from_write_sets_canonical_fields() -> None:
+    """Write manifest builder should populate required contract fields."""
+    payload = manifest_from_write(
+        "crypto/hourly/BTCUSD",
+        row_count=10,
+        schema=["timestamp", "close"],
+        custom={"provider": "cryptocompare"},
+        range_start=datetime(2024, 1, 1),
+        range_end=datetime(2024, 1, 2),
+    )
+
+    assert payload["manifest_version"] == MANIFEST_VERSION
+    assert payload["key"] == "crypto/hourly/BTCUSD"
+    assert payload["provider"] == "cryptocompare"
+    assert payload["symbol"] == "BTCUSD"
+    assert payload["asset_class"] == "crypto"
+    assert payload["frequency"] == "hourly"
+    assert payload["row_count"] == 10
+    assert payload["total_rows"] == 10
+    assert payload["data_range"]["start"].startswith("2024-01-01T00:00:00")
+    assert payload["data_range"]["end"].startswith("2024-01-02T00:00:00")
+
+
+def test_normalize_manifest_payload_adds_compatibility_aliases() -> None:
+    """Normalizer should provide stable aliases expected by existing managers."""
+    normalized = normalize_manifest_payload(
+        "futures/daily/ESZ4",
+        {
+            "provider": "databento",
+            "row_count": 3,
+            "update_history": [{"timestamp": "2024-01-01T00:00:00"}],
+            "last_update": "2024-01-05T00:00:00",
+        },
+    )
+
+    assert normalized["update_count"] == 1
+    assert normalized["attributes"]["last_update"] == "2024-01-05T00:00:00"
+    assert normalized["manifest_version"] == MANIFEST_VERSION
+
+
+def test_manifest_with_incremental_update_keeps_bounded_history() -> None:
+    """Incremental metadata updates should append and cap history safely."""
+    payload = {"provider": "yahoo", "symbol": "AAPL", "update_history": []}
+    for i in range(105):
+        payload = manifest_with_incremental_update(
+            "equities/daily/AAPL",
+            payload,
+            last_update=datetime(2024, 1, 1, 0, 0, i % 60),
+            records_added=i + 1,
+            chunk_file=f"chunk_{i}.parquet",
+            max_history=100,
+        )
+
+    assert len(payload["update_history"]) == 100
+    assert payload["update_history"][-1]["records_added"] == 105
+
+
+def test_upgrade_manifest_payload_emits_deprecation_for_unversioned() -> None:
+    """Legacy unversioned manifests should emit deprecation warnings on upgrade."""
+    with pytest.deprecated_call(match="without 'manifest_version'"):
+        upgraded, changed = upgrade_manifest_payload(
+            "equities/daily/AAPL",
+            {
+                "row_count": 5,
+                "custom": {"provider": "yahoo"},
+            },
+            emit_deprecation_warning=True,
+        )
+
+    assert changed is True
+    assert upgraded["manifest_version"] == MANIFEST_VERSION
+    assert upgraded["provider"] == "yahoo"
+
+
+def test_upgrade_manifest_payload_noop_for_current_v1() -> None:
+    """Already normalized v1 manifests should not be marked as changed."""
+    payload = manifest_from_write(
+        "equities/daily/MSFT",
+        row_count=7,
+        schema=["timestamp", "close"],
+        custom={"provider": "yahoo"},
+    )
+    upgraded, changed = upgrade_manifest_payload("equities/daily/MSFT", payload)
+
+    assert changed is False
+    assert upgraded == payload


### PR DESCRIPTION
## Summary
- add canonical storage key helpers and storage key codec
- add manifest normalization/upgrade helpers for backward-compatible metadata handling
- adopt encoded key paths and normalized manifest payloads across flat/hive/metadata tracker flows
- strengthen async/transaction/filesystem storage behavior and coverage

## Validation
- uv run ruff check src tests
- uv run ty check
- uv run pytest tests/core/test_keys.py tests/test_storage_key_codec.py tests/test_storage_manifest.py tests/test_storage_backends.py tests/test_hive_storage.py tests/test_metadata_tracker.py tests/test_async_storage.py tests/test_multi_asset.py tests/test_incremental_update_system.py tests/test_data_manager_storage.py tests/test_metadata_manager.py -q -ra
- uv run pytest tests -q -ra
- uv run pytest tests -q -ra -W error::ResourceWarning
