### PR TITLE
fix: normalize CLI update keys and metadata listing

### DIFF
--- a/.github/ISSUE_TEMPLATE/pr-checklist.yml
+++ b/.github/ISSUE_TEMPLATE/pr-checklist.yml
@@ -1,0 +1,90 @@
+name: PR Checklist - 1.0 Readiness Slice
+description: Actionable checklist for a scoped readiness PR (S/M/L) with acceptance criteria.
+title: "PR Slice: <S1/M1/L1> - <short title>"
+labels:
+  - enhancement
+  - quality
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template to execute one incremental readiness slice with clear scope, validation, and rollback safety.
+  - type: input
+    id: slice_id
+    attributes:
+      label: Slice ID
+      description: Use roadmap IDs like S1, S2, M1, L1.
+      placeholder: S1
+    validations:
+      required: true
+  - type: textarea
+    id: objective
+    attributes:
+      label: Objective
+      description: What this PR changes and why.
+      placeholder: Fix default provider routing and enforce canonical storage key normalization in CLI update path.
+    validations:
+      required: true
+  - type: textarea
+    id: in_scope
+    attributes:
+      label: In Scope
+      description: Explicitly list files/modules that this PR is allowed to modify.
+      value: |
+        - src/ml4t/data/...
+        - tests/...
+    validations:
+      required: true
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out Of Scope
+      description: Prevent scope creep.
+      value: |
+        - No unrelated refactors
+        - No dependency upgrades unless required
+    validations:
+      required: true
+  - type: checkboxes
+    id: implementation_checklist
+    attributes:
+      label: Implementation Checklist
+      options:
+        - label: Add/adjust core logic for this slice
+        - label: Keep behavior backward-compatible or add explicit migration handling
+        - label: Add/adjust tests covering happy path + edge path + regression path
+        - label: Update CLI/API contract where affected
+        - label: Keep changes minimal and focused
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance Criteria
+      description: Measurable completion conditions.
+      value: |
+        - [ ] Targeted tests for modified behavior pass locally
+        - [ ] No regressions in relevant existing tests
+        - [ ] Lint/type checks pass for touched code
+        - [ ] Behavior is deterministic and offline-testable
+    validations:
+      required: true
+  - type: textarea
+    id: validation_plan
+    attributes:
+      label: Validation Plan
+      description: Commands to run before merge.
+      value: |
+        uv run ruff check src/ tests/
+        uv run ty check
+        uv run pytest tests/<target_file_or_subset> -q
+    validations:
+      required: true
+  - type: textarea
+    id: risk_and_rollback
+    attributes:
+      label: Risk and Rollback
+      description: Main risks and rollback strategy if needed.
+      placeholder: |
+        Risk: routing logic changes provider defaults for ambiguous symbols.
+        Rollback: revert router default logic and keep key normalization utility isolated.
+    validations:
+      required: true

--- a/src/ml4t/data/cli/config.py
+++ b/src/ml4t/data/cli/config.py
@@ -140,7 +140,7 @@ def server(host, port, reload):
 
     except ImportError:
         console.print(
-            "[red]API dependencies not installed. Install with: pip install 'ml4t-data[api]'[/red]"
+            "[red]API dependencies not installed. Install with: uv add 'ml4t-data[all-providers]'[/red]"
         )
         raise click.Abort()
     except Exception as e:
@@ -150,7 +150,8 @@ def server(host, port, reload):
 
 @click.command("show-completion")
 @click.argument("shell", type=click.Choice(["bash", "zsh", "fish"]))
-def show_completion(shell):
+@click.pass_context
+def show_completion(ctx, shell):
     """Show shell completion script.
 
     To enable completion:
@@ -164,17 +165,13 @@ def show_completion(shell):
     Fish:
         eval (env _ML4T_DATA_COMPLETE=fish_source ml4t-data)
     """
-    import os
-    import subprocess
+    from click.shell_completion import get_completion_class
 
-    env = os.environ.copy()
-    env["_QDATA_COMPLETE"] = f"{shell}_source"
+    completion_class = get_completion_class(shell)
+    if completion_class is None:
+        raise click.Abort()
 
-    result = subprocess.run(
-        [sys.executable, "-m", "mlquant.data.cli_interface"],
-        env=env,
-        capture_output=True,
-        text=True,
-    )
-
-    console.print(result.stdout)
+    root_command = ctx.find_root().command
+    complete_var = "_ML4T_DATA_COMPLETE"
+    completion = completion_class(root_command, {}, "ml4t-data", complete_var)
+    console.print(completion.source())

--- a/src/ml4t/data/cli/core.py
+++ b/src/ml4t/data/cli/core.py
@@ -15,9 +15,12 @@ from rich import box
 from rich.panel import Panel
 from rich.table import Table
 
+from ml4t.data.core.keys import is_storage_key, normalize_storage_key, parse_storage_key
 from ml4t.data.data_manager import DataManager
 from ml4t.data.storage.backend import StorageConfig
 from ml4t.data.storage.hive import HiveStorage
+from ml4t.data.storage.key_codec import decode_storage_key
+from ml4t.data.storage.manifest import normalize_manifest_payload
 from ml4t.data.storage.metadata_tracker import MetadataTracker
 from ml4t.data.update_manager import IncrementalUpdater, UpdateStrategy
 
@@ -156,8 +159,15 @@ def fetch(ctx, symbol, symbols_file, start, end, frequency, provider, output, co
 )
 @click.option("--provider", "-p", help="Provider to use for fetching")
 @click.option("--storage-path", default="./data", help="Storage directory path")
+@click.option("--asset-class", default="equities", help="Asset class for storage key")
+@click.option(
+    "--frequency",
+    default="daily",
+    type=click.Choice(["daily", "hourly", "weekly"]),
+    help="Data frequency for storage key and fetching",
+)
 @click.pass_context
-def update(ctx, symbol, start, end, strategy, provider, storage_path):
+def update(ctx, symbol, start, end, strategy, provider, storage_path, asset_class, frequency):
     """Perform incremental data updates."""
     verbose = ctx.obj.get("verbose", False)
     quiet = ctx.obj.get("quiet", False)
@@ -169,6 +179,12 @@ def update(ctx, symbol, start, end, strategy, provider, storage_path):
 
         update_strategy = UpdateStrategy[strategy.upper()]
         updater = IncrementalUpdater(strategy=update_strategy)
+        storage_key = normalize_storage_key(
+            symbol_or_key=symbol,
+            asset_class=asset_class,
+            frequency=frequency,
+        )
+        fetch_symbol = parse_storage_key(storage_key)[2] if is_storage_key(symbol) else symbol
 
         if not end:
             end = datetime.now().strftime("%Y-%m-%d")
@@ -177,14 +193,14 @@ def update(ctx, symbol, start, end, strategy, provider, storage_path):
 
         actual_start, actual_end, update_type = updater.determine_update_range(
             storage,
-            symbol,
+            storage_key,
             datetime.strptime(start, "%Y-%m-%d"),
             datetime.strptime(end, "%Y-%m-%d"),
         )
 
         if update_type == "none":
             if not quiet:
-                print_success(f"Data already up to date for {symbol}")
+                print_success(f"Data already up to date for {fetch_symbol}")
             return
 
         if not quiet:
@@ -195,9 +211,10 @@ def update(ctx, symbol, start, end, strategy, provider, storage_path):
 
         dm = DataManager()
         new_data = dm.fetch(
-            symbol,
+            fetch_symbol,
             actual_start.strftime("%Y-%m-%d"),
             actual_end.strftime("%Y-%m-%d"),
+            frequency=frequency,
             provider=provider,
         )
 
@@ -209,7 +226,7 @@ def update(ctx, symbol, start, end, strategy, provider, storage_path):
         result = updater.update_incremental(
             storage,
             tracker,
-            symbol,
+            storage_key,
             new_data,
             provider=provider or "auto",
             strategy=update_strategy,
@@ -326,11 +343,20 @@ def validate(ctx, symbol, validate_all, anomalies, save_report, severity, storag
                         ReturnOutlierDetector,
                         VolumeSpikeDetector,
                     )
+                    from ml4t.data.anomaly.config import (
+                        PriceStalenessConfig,
+                        ReturnOutlierConfig,
+                        VolumeSpikeConfig,
+                    )
 
                     manager = AnomalyManager()
-                    manager.detectors.append(PriceStalenessDetector(max_gap_days=3))
-                    manager.detectors.append(ReturnOutlierDetector(threshold=5.0))
-                    manager.detectors.append(VolumeSpikeDetector(threshold=10.0))
+                    manager.detectors.append(
+                        PriceStalenessDetector(PriceStalenessConfig(max_unchanged_days=3))
+                    )
+                    manager.detectors.append(
+                        ReturnOutlierDetector(ReturnOutlierConfig(threshold=5.0))
+                    )
+                    manager.detectors.append(VolumeSpikeDetector(VolumeSpikeConfig(threshold=10.0)))
 
                     report = manager.analyze(df, symbol=sym, asset_class="unknown")
 
@@ -568,18 +594,23 @@ def list_data(_ctx, config, storage_path):
             with open(meta_file) as f:
                 meta = json_module.load(f)
 
-            custom = meta.get("custom", {})
-            provider = custom.get("provider")
-            symbol = custom.get("symbol")
+            decoded_key = decode_storage_key(meta_file.stem)
+            normalized = normalize_manifest_payload(decoded_key, meta)
+            provider = normalized.get("provider")
+            symbol = normalized.get("symbol")
 
             if not symbol or not provider:
                 continue
 
+            data_range = normalized.get("data_range")
+            if not isinstance(data_range, dict):
+                data_range = {}
+
             data_info = {
-                "rows": meta.get("row_count", 0),
-                "start": custom.get("start_date", ""),
-                "end": custom.get("end_date", ""),
-                "updated": custom.get("last_updated", ""),
+                "rows": normalized.get("row_count", normalized.get("total_rows", 0)),
+                "start": data_range.get("start", ""),
+                "end": data_range.get("end", ""),
+                "updated": normalized.get("last_updated", ""),
             }
 
             if provider == "databento":

--- a/src/ml4t/data/macro/downloader.py
+++ b/src/ml4t/data/macro/downloader.py
@@ -251,6 +251,7 @@ class MacroDataManager:
                     end=self.config.end,
                     progress=False,
                     auto_adjust=True,
+                    threads=False,
                 )
 
                 if df.empty:
@@ -281,7 +282,7 @@ class MacroDataManager:
         # Join all series on timestamp
         result = dfs[0]
         for df in dfs[1:]:
-            result = result.join(df, on="timestamp", how="outer_coalesce")
+            result = result.join(df, on="timestamp", how="full", coalesce=True)
 
         return result.sort("timestamp")
 

--- a/tests/test_cli_interface.py
+++ b/tests/test_cli_interface.py
@@ -12,6 +12,7 @@ import pytest
 from click.testing import CliRunner
 
 from ml4t.data.cli_interface import cli
+from ml4t.data.storage.key_codec import encode_storage_key
 
 
 class TestCLIBasics:
@@ -216,7 +217,6 @@ class TestUpdateCommand:
     @patch("ml4t.data.cli.core.MetadataTracker")
     @patch("ml4t.data.cli.core.IncrementalUpdater")
     @patch("ml4t.data.cli.core.DataManager")
-    @pytest.mark.skip(reason="CLI mock/config issues in PRE-RELEASE")
     def test_update_incremental(
         self, mock_dm_class, mock_updater_class, mock_tracker_class, mock_storage_class
     ):
@@ -247,6 +247,7 @@ class TestUpdateCommand:
         mock_result.success = True
         mock_result.rows_added = 5
         mock_result.rows_updated = 0
+        mock_result.gaps_filled = 0
         mock_updater.update_incremental.return_value = mock_result
 
         runner = CliRunner()
@@ -305,6 +306,49 @@ class TestUpdateCommand:
 
             assert result.exit_code == 0
             assert "Data already up to date" in result.output
+            mock_updater.determine_update_range.assert_called_once()
+            args = mock_updater.determine_update_range.call_args[0]
+            assert args[1] == "equities/daily/BTC"
+
+    @patch("ml4t.data.cli.core.HiveStorage")
+    @patch("ml4t.data.cli.core.MetadataTracker")
+    @patch("ml4t.data.cli.core.IncrementalUpdater")
+    def test_update_preserves_explicit_storage_key(
+        self, mock_updater_class, mock_tracker_class, mock_storage_class
+    ):
+        """Test update uses explicit key when canonical key is passed."""
+        mock_updater = MagicMock()
+        mock_updater_class.return_value = mock_updater
+        mock_storage = MagicMock()
+        mock_storage_class.return_value = mock_storage
+        mock_tracker = MagicMock()
+        mock_tracker_class.return_value = mock_tracker
+
+        mock_updater.determine_update_range.return_value = (
+            datetime(2024, 1, 10),
+            datetime(2024, 1, 10),
+            "none",
+        )
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(
+                cli,
+                [
+                    "update",
+                    "--symbol",
+                    "crypto/hourly/BTC",
+                    "--start",
+                    "2024-01-01",
+                    "--end",
+                    "2024-01-10",
+                ],
+            )
+
+            assert result.exit_code == 0
+            mock_updater.determine_update_range.assert_called_once()
+            args = mock_updater.determine_update_range.call_args[0]
+            assert args[1] == "crypto/hourly/BTC"
 
 
 class TestValidateCommand:
@@ -422,7 +466,6 @@ class TestStatusCommand:
 
     @patch("ml4t.data.cli.core.MetadataTracker")
     @patch("ml4t.data.cli.core.HiveStorage")
-    @pytest.mark.skip(reason="CLI mock/config issues in PRE-RELEASE")
     def test_status_detailed(self, mock_storage_class, mock_tracker_class):
         """Test detailed status with --detailed flag."""
         mock_storage = MagicMock()
@@ -430,6 +473,15 @@ class TestStatusCommand:
         mock_tracker = MagicMock()
         mock_tracker_class.return_value = mock_tracker
 
+        mock_tracker.get_summary.return_value = {
+            "total_datasets": 1,
+            "healthy": 1,
+            "stale": 0,
+            "error": 0,
+            "total_rows": 10,
+            "total_updates": 1,
+            "by_asset_class": {"crypto": 1},
+        }
         mock_storage.list_keys.return_value = ["BTC"]
 
         # Mock detailed metadata
@@ -497,13 +549,12 @@ class TestBatchOperations:
             assert "Fetching 2 symbols from file" in result.output
 
     @patch("ml4t.data.cli.core.DataManager")
-    @pytest.mark.skip(reason="CLI mock/config issues in PRE-RELEASE")
     def test_fetch_with_config(self, mock_dm_class):
         """Test fetching with configuration file."""
         mock_dm = MagicMock()
         mock_dm_class.return_value = mock_dm
         mock_df = pl.DataFrame({"timestamp": [datetime(2024, 1, 1)]})
-        mock_dm.fetch.return_value = mock_df
+        mock_dm.fetch_batch.return_value = {"BTC": mock_df, "ETH": mock_df}
 
         runner = CliRunner()
         with runner.isolated_filesystem():
@@ -524,11 +575,18 @@ class TestBatchOperations:
                     "fetch",
                     "--config",
                     "config.json",
+                    "--start",
+                    "2020-01-01",
+                    "--end",
+                    "2020-01-31",
                 ],
             )
 
             assert result.exit_code == 0
             assert "Loading configuration from config.json" in result.output
+            mock_dm.fetch_batch.assert_called_once_with(
+                ["BTC", "ETH"], "2024-01-01", "2024-01-31", frequency="hourly"
+            )
 
 
 class TestProgressAndOutput:
@@ -573,37 +631,33 @@ class TestProgressAndOutput:
         # Progress indicators should be in output
         assert "Fetching 5 symbols" in result.output
 
-    @pytest.mark.skip(reason="CLI mock/config issues in PRE-RELEASE")
     def test_quiet_mode(self):
         """Test quiet mode suppresses output."""
         runner = CliRunner()
-        result = runner.invoke(cli, ["status", "--quiet"])
+        result = runner.invoke(cli, ["--quiet", "status"])
         assert result.exit_code == 0
         # Only essential output, no decorative elements
         assert "═" not in result.output  # No box drawing
 
-    @pytest.mark.skip(reason="Verbose output format is implementation-specific")
     def test_verbose_mode(self):
         """Test verbose mode shows detailed information."""
         runner = CliRunner()
         result = runner.invoke(cli, ["--verbose", "status"])
         assert result.exit_code == 0
-        # Should show debug information
-        assert "Configuration" in result.output or "Debug" in result.output
+        assert "Storage path:" in result.output
 
 
 class TestShellCompletion:
     """Test shell completion support."""
 
-    @pytest.mark.skip(reason="CLI mock/config issues in PRE-RELEASE")
     def test_completion_installation(self):
         """Test shell completion installation command."""
         runner = CliRunner()
 
         # Test bash completion
-        result = runner.invoke(cli, ["--show-completion", "bash"])
+        result = runner.invoke(cli, ["show-completion", "bash"])
         assert result.exit_code == 0
-        assert "_QDATA_COMPLETE" in result.output
+        assert "_ML4T_DATA_COMPLETE" in result.output
 
     def test_completion_symbols(self):
         """Test symbol completion suggestions."""
@@ -1361,6 +1415,45 @@ datasets: {}
 
         # Should not crash
         assert result.exit_code == 0
+
+    def test_list_reads_top_level_manifest_fields(self):
+        """Test list command can parse manifests without custom payload."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            storage_path = Path("data")
+            metadata_dir = storage_path / ".metadata"
+            metadata_dir.mkdir(parents=True)
+
+            key = "futures/daily/ESZ4"
+            metadata_file = metadata_dir / f"{encode_storage_key(key)}.json"
+            metadata_file.write_text(
+                json.dumps(
+                    {
+                        "provider": "databento",
+                        "symbol": "ESZ4",
+                        "row_count": 15,
+                        "data_range": {
+                            "start": "2024-01-01T00:00:00",
+                            "end": "2024-01-15T00:00:00",
+                        },
+                        "last_update": "2024-01-15T12:00:00",
+                    }
+                )
+            )
+
+            Path("config.yaml").write_text(
+                """
+storage:
+  path: data
+datasets: {}
+"""
+            )
+
+            result = runner.invoke(cli, ["list", "-c", "config.yaml"])
+
+        assert result.exit_code == 0
+        assert "Futures (DataBento)" in result.output
+        assert "ESZ4" in result.output
 
 
 class TestDownloadFuturesCommand:

--- a/tests/test_fama_french_provider.py
+++ b/tests/test_fama_french_provider.py
@@ -290,7 +290,6 @@ class TestFetch:
             assert len(df) == 1
             assert df["Mkt-RF"][0] == 0.01
 
-    @pytest.mark.xfail(reason="Provider date filtering has type mismatch bug")
     def test_fetch_date_filtering(self):
         """Test fetch with start/end date filtering."""
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary
- normalize CLI update symbols into canonical storage keys while preserving explicit keys
- parse metadata list output through manifest/key normalization utilities
- modernize CLI completion generation and expand CLI regression coverage

## Validation
- uv run ruff check src tests
- uv run ty check
- uv run pytest tests/test_cli_interface.py -q -ra
