### PR TITLE
chore: refine macro downloader joins and add PR slice checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE/pr-checklist.yml
+++ b/.github/ISSUE_TEMPLATE/pr-checklist.yml
@@ -1,0 +1,90 @@
+name: PR Checklist - 1.0 Readiness Slice
+description: Actionable checklist for a scoped readiness PR (S/M/L) with acceptance criteria.
+title: "PR Slice: <S1/M1/L1> - <short title>"
+labels:
+  - enhancement
+  - quality
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template to execute one incremental readiness slice with clear scope, validation, and rollback safety.
+  - type: input
+    id: slice_id
+    attributes:
+      label: Slice ID
+      description: Use roadmap IDs like S1, S2, M1, L1.
+      placeholder: S1
+    validations:
+      required: true
+  - type: textarea
+    id: objective
+    attributes:
+      label: Objective
+      description: What this PR changes and why.
+      placeholder: Fix default provider routing and enforce canonical storage key normalization in CLI update path.
+    validations:
+      required: true
+  - type: textarea
+    id: in_scope
+    attributes:
+      label: In Scope
+      description: Explicitly list files/modules that this PR is allowed to modify.
+      value: |
+        - src/ml4t/data/...
+        - tests/...
+    validations:
+      required: true
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out Of Scope
+      description: Prevent scope creep.
+      value: |
+        - No unrelated refactors
+        - No dependency upgrades unless required
+    validations:
+      required: true
+  - type: checkboxes
+    id: implementation_checklist
+    attributes:
+      label: Implementation Checklist
+      options:
+        - label: Add/adjust core logic for this slice
+        - label: Keep behavior backward-compatible or add explicit migration handling
+        - label: Add/adjust tests covering happy path + edge path + regression path
+        - label: Update CLI/API contract where affected
+        - label: Keep changes minimal and focused
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance Criteria
+      description: Measurable completion conditions.
+      value: |
+        - [ ] Targeted tests for modified behavior pass locally
+        - [ ] No regressions in relevant existing tests
+        - [ ] Lint/type checks pass for touched code
+        - [ ] Behavior is deterministic and offline-testable
+    validations:
+      required: true
+  - type: textarea
+    id: validation_plan
+    attributes:
+      label: Validation Plan
+      description: Commands to run before merge.
+      value: |
+        uv run ruff check src/ tests/
+        uv run ty check
+        uv run pytest tests/<target_file_or_subset> -q
+    validations:
+      required: true
+  - type: textarea
+    id: risk_and_rollback
+    attributes:
+      label: Risk and Rollback
+      description: Main risks and rollback strategy if needed.
+      placeholder: |
+        Risk: routing logic changes provider defaults for ambiguous symbols.
+        Rollback: revert router default logic and keep key normalization utility isolated.
+    validations:
+      required: true

--- a/src/ml4t/data/macro/downloader.py
+++ b/src/ml4t/data/macro/downloader.py
@@ -251,6 +251,7 @@ class MacroDataManager:
                     end=self.config.end,
                     progress=False,
                     auto_adjust=True,
+                    threads=False,
                 )
 
                 if df.empty:
@@ -281,7 +282,7 @@ class MacroDataManager:
         # Join all series on timestamp
         result = dfs[0]
         for df in dfs[1:]:
-            result = result.join(df, on="timestamp", how="outer_coalesce")
+            result = result.join(df, on="timestamp", how="full", coalesce=True)
 
         return result.sort("timestamp")
 

--- a/tests/test_fama_french_provider.py
+++ b/tests/test_fama_french_provider.py
@@ -290,7 +290,6 @@ class TestFetch:
             assert len(df) == 1
             assert df["Mkt-RF"][0] == 0.01
 
-    @pytest.mark.xfail(reason="Provider date filtering has type mismatch bug")
     def test_fetch_date_filtering(self):
         """Test fetch with start/end date filtering."""
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary
- align macro downloader join semantics with current polars API
- tighten yahoo macro download threading behavior for deterministic execution
- add PR checklist issue template for readiness slice workflow

## Validation
- uv run ruff check src tests
- uv run ty check
- uv run pre-commit run check-yaml --files .github/ISSUE_TEMPLATE/pr-checklist.yml
- uv run pytest tests/test_fama_french_provider.py -q -ra
- uv run pytest tests -q -ra
- uv run pytest tests -q -ra -W error::ResourceWarning
