### PR TITLE
docs: correct provider counts and fix AGENT.md references

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -18,7 +18,7 @@ Market data acquisition and storage library for ML4T 3rd Edition.
 | `futures/`    | Databento futures downloaders and roll logic   |
 | `etfs/`       | ETFDataManager for Yahoo Finance ETF data      |
 | `crypto/`     | CryptoDataManager for Binance premium index    |
-| `providers/`  | 22 data source integrations                    |
+| `providers/`  | 20 live provider adapters + synthetic/testing providers |
 | `storage/`    | Hive-partitioned Parquet + ProfileMixin        |
 | `managers/`   | Data orchestration and updates                 |
 | `assets/`     | Asset universe definitions                     |

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Each library addresses a distinct stage: data infrastructure, feature engineerin
 
 Quantitative research requires consistent, reproducible access to market data from multiple sources. ml4t-data provides:
 
-- A unified interface across 19 data providers (equities, crypto, forex, futures, economic data)
+- A unified interface across 20 live provider adapters (plus synthetic/testing providers)
 - Automated storage in Hive-partitioned Parquet format with metadata tracking
 - Incremental updates, gap detection, and backfill capabilities via CLI
 - Built-in data validation (OHLC invariants, deduplication, anomaly detection)
@@ -57,7 +57,7 @@ fred = FREDProvider().fetch_series("GDP", "2020-01-01", "2024-12-31")
 
 ## Data Providers
 
-### Free (No API Key)
+### No API Key Required
 
 | Provider | Coverage |
 |----------|----------|
@@ -65,16 +65,20 @@ fred = FREDProvider().fetch_series("GDP", "2020-01-01", "2024-12-31")
 | CoinGecko | 10,000+ cryptocurrencies |
 | FRED | 850,000 economic series |
 | Fama-French | Academic factor data |
-| AQR | Alternative factors (QMJ, BAB, TSMOM) |
+| AQR | Research factors (QMJ, BAB, HML Devil, VME, more) |
+| Wiki Prices | Frozen US equities history (1962-2018) |
+| Kalshi | Prediction market contracts |
+| Polymarket | Prediction market history/order book snapshots |
+| Binance Public | Bulk crypto data downloads |
+| NASDAQ ITCH Sample | Tick-level sample data |
 
-### API Key Required
+### Authenticated or Metered APIs
 
 | Provider | Coverage |
 |----------|----------|
 | EODHD | 60+ global exchanges |
 | Tiingo | US equities with quality focus |
 | Twelve Data | Multi-asset coverage |
-| Alpha Vantage | Equities, forex, crypto |
 | Databento | CME, CBOE, ICE futures/options |
 | Polygon | US equities, options, forex, crypto |
 | Finnhub | 70+ global exchanges |

--- a/src/ml4t/data/AGENT.md
+++ b/src/ml4t/data/AGENT.md
@@ -13,7 +13,7 @@
 
 | Directory | Lines | Purpose |
 |-----------|-------|---------|
-| providers/ | 14k | 22 data source integrations |
+| providers/ | 14k | 20 live provider adapters + synthetic/testing providers |
 | storage/ | 4.6k | Hive-partitioned backends + profiling |
 | futures/ | 4.6k | Databento futures downloader |
 | etfs/ | 600 | ETFDataManager (Yahoo Finance) |

--- a/src/ml4t/data/providers/AGENT.md
+++ b/src/ml4t/data/providers/AGENT.md
@@ -1,10 +1,10 @@
-# providers/ - 22 Data Sources
+# providers/ - Provider Adapters
 
 ## Base Classes
 
 | File | Lines | Purpose |
 |------|-------|---------|
-| base.py | 290 | BaseDataProvider abstract |
+| base.py | 290 | `BaseProvider` abstract base |
 | async_base.py | 256 | AsyncBaseProvider |
 | protocols.py | 249 | Provider protocols |
 
@@ -51,4 +51,4 @@
 
 ## Key
 
-`get_provider()`, `BaseDataProvider`, `fetch_ohlcv()`
+`BaseProvider`, `Provider`, `fetch_ohlcv()`, `fetch_series()`, `fetch()`


### PR DESCRIPTION
## Summary
- Correct provider count from 22/19 to 20 live providers + synthetic/testing
- Fix BaseProvider class name reference in providers/AGENT.md
- Update README provider table to include all free-tier and metered APIs
- Remove Alpha Vantage (no provider implementation exists)

## Test plan
- [ ] No code changes — doc-only PR