### PR TITLE
fix: unify AssetClass to single canonical enum

### DIFF
--- a/src/ml4t/data/assets/asset_class.py
+++ b/src/ml4t/data/assets/asset_class.py
@@ -8,7 +8,12 @@ from typing import Any, ClassVar
 
 
 class AssetClass(str, Enum):
-    """Supported asset classes."""
+    """Supported asset classes.
+
+    Canonical enum for all asset class references across ml4t-data.
+    Plural aliases (EQUITIES, FUTURES, OPTIONS) are provided for backward
+    compatibility with config files and serialized data.
+    """
 
     EQUITY = "equity"
     CRYPTO = "crypto"
@@ -19,6 +24,11 @@ class AssetClass(str, Enum):
     ETF = "etf"
     OPTION = "option"
     FUTURE = "future"
+
+    # Plural aliases for backward compatibility
+    EQUITIES = "equities"
+    FUTURES = "futures"
+    OPTIONS = "options"
 
 
 @dataclass

--- a/src/ml4t/data/config/models.py
+++ b/src/ml4t/data/config/models.py
@@ -11,8 +11,8 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-# Import consolidated enums from core.models
-from ml4t.data.core.models import AssetClass, Frequency
+from ml4t.data.assets.asset_class import AssetClass
+from ml4t.data.core.models import Frequency
 
 
 # Storage configuration enums

--- a/src/ml4t/data/core/models.py
+++ b/src/ml4t/data/core/models.py
@@ -1,4 +1,4 @@
-"""Core data models for QLDM."""
+"""Core data models for ml4t-data."""
 
 from __future__ import annotations
 
@@ -9,6 +9,8 @@ from typing import Any
 import polars as pl
 from pydantic import BaseModel, Field, model_validator
 
+from ml4t.data.assets.asset_class import AssetClass  # noqa: F401 — re-exported
+
 
 class SchemaVersion(str, Enum):
     """Schema version for data storage."""
@@ -16,35 +18,8 @@ class SchemaVersion(str, Enum):
     V1_0 = "1.0"
 
 
-class AssetClass(str, Enum):
-    """Supported asset classes.
-
-    Consolidated from multiple definitions across the codebase.
-    Uses 'equities' as canonical since it's more widely used in the codebase.
-    """
-
-    # Primary values (widely used in codebase)
-    EQUITIES = "equities"  # Most widely used in current codebase
-    CRYPTO = "crypto"
-    FOREX = "forex"
-    COMMODITY = "commodity"
-    FIXED_INCOME = "fixed_income"
-    INDEX = "index"
-    ETF = "etf"
-    FUTURES = "futures"
-    OPTIONS = "options"
-
-    # Aliases for backward compatibility
-    EQUITY = "equity"  # Alias for EQUITIES
-    OPTION = "option"  # Alias for OPTIONS
-    FUTURE = "future"  # Alias for FUTURES
-
-
 class Frequency(str, Enum):
-    """Data frequency.
-
-    Consolidated from multiple definitions across the codebase.
-    """
+    """Data frequency."""
 
     # High-frequency data
     TICK = "tick"

--- a/src/ml4t/data/futures/__init__.py
+++ b/src/ml4t/data/futures/__init__.py
@@ -82,12 +82,14 @@ from ml4t.data.futures.schema import (
     AssetClass,
     ContractSpec,
     ExchangeInfo,
+    FuturesAssetClass,
     SettlementType,
 )
 
 __all__ = [
     # Schema
-    "AssetClass",
+    "AssetClass",  # Backward compat alias for FuturesAssetClass
+    "FuturesAssetClass",
     "ContractSpec",
     "ExchangeInfo",
     "MAJOR_CONTRACTS",

--- a/src/ml4t/data/futures/schema.py
+++ b/src/ml4t/data/futures/schema.py
@@ -17,8 +17,12 @@ from dataclasses import dataclass
 from enum import Enum
 
 
-class AssetClass(str, Enum):
-    """Asset class classification for futures contracts."""
+class FuturesAssetClass(str, Enum):
+    """Asset class classification for futures contracts.
+
+    This is a futures-specific taxonomy, distinct from the general
+    AssetClass enum in ml4t.data.assets.asset_class.
+    """
 
     EQUITY_INDEX = "equity_index"
     ENERGY = "energy"
@@ -27,6 +31,10 @@ class AssetClass(str, Enum):
     CURRENCY = "currency"
     FIXED_INCOME = "fixed_income"
     VOLATILITY = "volatility"
+
+
+# Backward compatibility alias
+AssetClass = FuturesAssetClass
 
 
 class SettlementType(str, Enum):
@@ -94,7 +102,7 @@ class ContractSpec:
     ticker: str
     name: str
     exchange: str
-    asset_class: AssetClass
+    asset_class: FuturesAssetClass
     multiplier: float
     tick_size: float
     tick_value: float

--- a/src/ml4t/data/validation/rules.py
+++ b/src/ml4t/data/validation/rules.py
@@ -9,13 +9,9 @@ import structlog
 import yaml
 from pydantic import BaseModel, Field
 
-# Import consolidated enums from core.models
-from ml4t.data.core.models import AssetClass
+from ml4t.data.assets.asset_class import AssetClass
 
 logger = structlog.get_logger()
-
-
-# AssetClass enum imported from core.models
 
 
 class ValidationRuleConfig(BaseModel):


### PR DESCRIPTION
## Summary
- Keep `assets/asset_class.py` as the single canonical `AssetClass` enum
- Add plural aliases (EQUITIES, FUTURES, OPTIONS) for backward compatibility
- Remove duplicate definition from `core/models.py` (re-export instead)
- Rename `futures/schema.py` enum to `FuturesAssetClass` (different taxonomy)
- Update imports in `config/models.py` and `validation/rules.py`

## Test plan
- [x] All 2844 tests pass
- [x] Import paths verified: `ml4t.data.AssetClass`, `ml4t.data.core.models.AssetClass`, `ml4t.data.futures.schema.FuturesAssetClass`
- [x] Backward compat: `from ml4t.data.futures.schema import AssetClass` still works (alias)