### PR TITLE
docs: beta-readiness documentation overhaul

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,183 @@
+# Contributing to ml4t-data
+
+Thank you for your interest in contributing to ml4t-data. This guide covers everything you need to get started.
+
+## Development Setup
+
+```bash
+# Clone the repository
+git clone https://github.com/ml4t/data.git ml4t-data
+cd ml4t-data
+
+# Install dependencies (requires uv)
+uv sync --dev
+
+# Install pre-commit hooks
+uv run pre-commit install
+
+# Verify your setup
+uv run pytest tests/ -q
+```
+
+**Requirements**: Python 3.11+ and [uv](https://docs.astral.sh/uv/).
+
+## Quality Gates
+
+All changes must pass these checks before merging:
+
+```bash
+# Lint and format
+uv run ruff check src/ tests/
+uv run ruff format --check src/ tests/
+
+# Type check
+uv run ty check
+
+# Tests (core suite, excludes integration/slow/paid)
+uv run pytest tests/ -q
+
+# Resource leak check
+uv run pytest tests/ -q -W error::ResourceWarning
+
+# Run everything at once
+uv run pre-commit run --all-files
+```
+
+## Code Style
+
+- **Formatter/linter**: [ruff](https://docs.astral.sh/ruff/) (100 char line length)
+- **Type checker**: [ty](https://docs.astral.sh/ty/) (Astral) -- not mypy
+- **Type hints**: required on all public functions
+- **Docstrings**: Google style
+- **Imports**: sorted by ruff (stdlib, third-party, local)
+- **DataFrames**: Polars as primary, Pandas for compatibility
+
+All style rules are configured in `pyproject.toml` under `[tool.ruff]` and `[tool.ty]`. Ruff auto-fixes most issues via pre-commit.
+
+## Testing
+
+### Running Tests
+
+```bash
+# Default: core tests only (fast, no API keys needed)
+uv run pytest tests/ -q
+
+# Verbose with full output
+uv run pytest tests/ -v
+
+# Run a specific file or test
+uv run pytest tests/test_core_models.py -q
+uv run pytest tests/test_core_models.py::test_function_name
+
+# Run tests matching a pattern
+uv run pytest -k "yahoo" -q
+
+# Stop on first failure
+uv run pytest tests/ -x
+```
+
+### Test Markers
+
+Tests are organized by marker. The default `pytest` invocation skips slow, integration, and paid-tier tests.
+
+| Marker | Description | Default |
+|--------|-------------|---------|
+| `slow` | Tests taking >10 seconds | Skipped |
+| `integration` | Real API calls to external services | Skipped |
+| `requires_api_key` | Needs a specific API key in env | Skipped |
+| `paid_tier` | Requires paid API subscription | Skipped |
+| `optional_dependency` | Requires optional heavy dependency | Skipped |
+| `expensive` | High API cost | Skipped |
+
+To run a specific marker lane:
+
+```bash
+# Integration tests (requires API keys in environment)
+uv run pytest -m integration -q
+
+# All tests, ignoring marker filters
+uv run pytest -m "" -q
+```
+
+### Writing Tests
+
+- Place tests in `tests/` mirroring the source layout
+- Use `pytest` fixtures in `conftest.py` for shared setup
+- Mark integration tests with `@pytest.mark.integration`
+- Ensure OHLCV invariants hold: `high >= low`, `high >= open`, `high >= close`
+
+## Pull Request Workflow
+
+1. **Create a feature branch** from `main`:
+   ```bash
+   git checkout -b feat/my-feature
+   ```
+
+2. **Make your changes** with tests. Ensure all quality gates pass:
+   ```bash
+   uv run pre-commit run --all-files
+   uv run pytest tests/ -q
+   ```
+
+3. **Push and open a PR**:
+   ```bash
+   git push -u origin feat/my-feature
+   gh pr create --title "feat: description" --body "..."
+   ```
+
+4. **CI runs automatically** on the PR. All checks must pass before merge:
+   - Lint (ruff check + format)
+   - Type Check (ty)
+   - Test Core (Python 3.11, 3.12, 3.13)
+   - Package Build
+
+5. **Address review feedback**, then the PR is squash-merged into `main`.
+
+## Commit Message Format
+
+Use conventional commit prefixes:
+
+| Prefix | Use for |
+|--------|---------|
+| `feat:` | New feature or capability |
+| `fix:` | Bug fix |
+| `docs:` | Documentation changes |
+| `refactor:` | Code restructuring (no behavior change) |
+| `test:` | Adding or updating tests |
+| `chore:` | Maintenance, dependencies, CI |
+
+Examples:
+```
+feat: add Stooq provider for international equities
+fix: handle empty response in Yahoo provider
+test: add integration tests for Binance websocket
+refactor: extract common HTTP retry logic to base class
+```
+
+## Adding a New Provider
+
+Providers inherit from `BaseProvider` and implement three methods:
+
+1. `name()` -- lowercase provider identifier
+2. `_fetch_raw_data()` -- API call, returns raw response
+3. `_transform_data()` -- converts raw data to standard Polars DataFrame
+
+See `docs/contributing/creating-a-provider.md` for a full walkthrough and `src/ml4t/data/providers/` for existing implementations.
+
+## Project Structure
+
+```
+src/ml4t/data/
+├── providers/      # 20+ data source implementations
+├── storage/        # Hive-partitioned Parquet backends
+├── futures/        # CME/CBOE/ICE futures pipelines
+├── validation/     # OHLCV schema and quality checks
+├── config/         # Pydantic configuration models
+├── cli/            # Click CLI interface
+└── utils/          # Rate limiting, retry, formatting
+```
+
+## Getting Help
+
+- [GitHub Issues](https://github.com/ml4t/data/issues) -- bug reports and feature requests
+- [GitHub Discussions](https://github.com/ml4t/data/discussions) -- questions and ideas

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ fred = FREDProvider().fetch_series("GDP", "2020-01-01", "2024-12-31")
 | Polygon | US equities, options, forex, crypto |
 | Finnhub | 70+ global exchanges |
 | Binance | Crypto exchange data |
+| OKX | Crypto perpetuals and funding rates |
+| CryptoCompare | Crypto market data |
 | OANDA | Forex broker data |
 
 ## CLI for Automated Updates

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -238,8 +238,8 @@ for symbol in symbols:
 - `ml4t-book` (third edition) - 6 example notebooks
 
 ### Coordinate Breaking Changes With
-- `/home/stefan/ml4t/software/.claude/`
-- Parent-level context for multi-library workflows
+- Parent-level context in the `ml4t/libraries/` workspace
+- Multi-library workflows coordinated at the workspace level
 
 ---
 
@@ -350,9 +350,9 @@ ml4t-data export -s AAPL --output data.xlsx
 ## Documentation Links
 
 - **Full Inventory**: See comprehensive feature list above
-- **README**: `/home/stefan/ml4t/software/data/README.md` (8000+ lines)
-- **Project Map**: `/home/stefan/ml4t/software/data/.claude/PROJECT_MAP.md`
-- **Book Integration**: 6 example notebooks in `/home/stefan/ml4t/third_edition/`
+- **README**: `../README.md`
+- **Project Map**: See AGENT.md files at each package level
+- **Book Integration**: 6 example notebooks (ML4T third edition)
 - **Performance Analysis**: `PERFORMANCE_BENCHMARKS.md` and `PERFORMANCE_ANALYSIS.md`
 
 ---

--- a/docs/FEATURE_INVENTORY.md
+++ b/docs/FEATURE_INVENTORY.md
@@ -1,7 +1,7 @@
 # ML4T-Data: Comprehensive Feature Inventory
 
 **Library**: ml4t-data
-**Location**: `/home/stefan/ml4t/software/data/`
+**Location**: `src/ml4t/data/`
 **Version**: 0.1.0 (pre-release)
 **Status**: 🚧 Active Development (breaking changes acceptable)
 **Python**: 3.9+
@@ -13,7 +13,7 @@
 
 ML4T-Data is a production-ready market data acquisition library providing:
 
-- **13 Data Providers** (12 active + 1 historical fallback)
+- **20 Live Data Providers** (plus 3 synthetic/testing providers)
 - **Unified API** across crypto, equities, forex, and futures
 - **Incremental Update Infrastructure** with gap detection and resume capability
 - **7x Performance** improvement with Hive-partitioned Parquet storage
@@ -28,31 +28,42 @@ ML4T-Data is a production-ready market data acquisition library providing:
 
 ## Feature Category Inventory
 
-### 1. DATA PROVIDERS (15 Total: 13 Active + 1 Historical + 1 Mock)
+### 1. DATA PROVIDERS (23 Total: 20 Live + 3 Synthetic/Testing)
 
-#### Actively Maintained Providers
+#### Live Providers (No API Key Required)
 
 | # | Provider | File | Asset Classes | Free Tier | Status | Key Features |
 |---|----------|------|----------------|-----------|--------|--------------|
-| 1 | **Yahoo Finance** | `yahoo.py` | Equities, Crypto | Unlimited | ✅ Complete | US stocks, ETFs, indices |
-| 2 | **EODHD** | `eodhd.py` | Equities, Forex, Crypto | 500 calls/day | ✅ Complete | 60+ exchanges, global coverage |
-| 3 | **CoinGecko** | `coingecko.py` | Crypto | Free (50 req/min) | ✅ Complete | 10,000+ cryptocurrencies |
-| 4 | **Tiingo** | `tiingo.py` | Equities | 1000 req/day | ✅ Complete | US stocks alternative |
-| 5 | **Finnhub** | `finnhub.py` | Equities, Forex, Crypto | 60 req/min | ✅ Complete | Global market data (paid OHLCV) |
-| 6 | **Twelve Data** | `twelve_data.py` | Equities, Forex, Crypto | 800 calls/day | ✅ Complete | Multi-asset coverage |
-| 7 | **Polygon.io** | `polygon.py` | Equities, Options, Crypto, Forex | Limited | ✅ Complete | US market data (paid tier) |
-| 8 | **Binance** | `binance.py` | Crypto | Generous | ✅ Complete | Spot + futures, high-frequency |
-| 9 | **CryptoCompare** | `cryptocompare.py` | Crypto | 250k calls/mo | ✅ Complete | Historical crypto data |
-| 10 | **Oanda** | `oanda.py` | Forex | Trial | ✅ Complete | Institutional forex data |
-| 11 | **DataBento** | `databento.py` | Futures, Equities | Trial ($10 credits) | ✅ Complete | Institutional market data |
-| 12 | **Wiki Prices** | `wiki_prices.py` | Equities | Local file only | ✅ Complete | Historical US equities (1962-2018) |
+| 1 | **Yahoo Finance** | `yahoo.py` | Equities, Crypto | Unlimited | Complete | US stocks, ETFs, indices |
+| 2 | **CoinGecko** | `coingecko.py` | Crypto | Free (50 req/min) | Complete | 10,000+ cryptocurrencies |
+| 3 | **FRED** | `fred.py` | Economic Data | 120 req/min | Complete | 850,000 economic series |
+| 4 | **Fama-French** | `fama_french.py` | Factors | Unlimited | Complete | Academic factor data |
+| 5 | **AQR** | `aqr.py` | Factors | Unlimited | Complete | Research factors (QMJ, BAB, VME) |
+| 6 | **Wiki Prices** | `wiki_prices.py` | Equities | Local file only | Complete | Historical US equities (1962-2018) |
+| 7 | **Kalshi** | `kalshi.py` | Prediction Markets | Public data | Complete | Prediction market contracts |
+| 8 | **Polymarket** | `polymarket.py` | Prediction Markets | Public data | Complete | Prediction market history |
+| 9 | **Binance Public** | `binance_public.py` | Crypto | Bulk downloads | Complete | No geo-restrictions |
+| 10 | **NASDAQ ITCH** | `nasdaq_itch.py` | Tick Data | Sample data | Complete | Tick-level market data |
+
+#### Live Providers (Authenticated or Metered)
+
+| # | Provider | File | Asset Classes | Free Tier | Status | Key Features |
+|---|----------|------|----------------|-----------|--------|--------------|
+| 11 | **EODHD** | `eodhd.py` | Equities, Forex, Crypto | 500 calls/day | Complete | 60+ exchanges, global coverage |
+| 12 | **Tiingo** | `tiingo.py` | Equities | 1000 req/day | Complete | US stocks alternative |
+| 13 | **Twelve Data** | `twelve_data.py` | Equities, Forex, Crypto | 800 calls/day | Complete | Multi-asset coverage |
+| 14 | **DataBento** | `databento.py` | Futures, Equities | Trial ($10 credits) | Complete | Institutional market data |
+| 15 | **Polygon.io** | `polygon.py` | Equities, Options, Crypto, Forex | Limited | Complete | US market data (paid tier) |
+| 16 | **Finnhub** | `finnhub.py` | Equities, Forex, Crypto | 60 req/min | Complete | Global market data |
+| 17 | **Binance** | `binance.py` | Crypto | Generous | Complete | Spot + futures, high-frequency |
+| 18 | **OKX** | `okx.py` | Crypto | No geo-limits | Complete | Perpetuals, funding rates |
+| 19 | **CryptoCompare** | `cryptocompare.py` | Crypto | 250k calls/mo | Complete | Historical crypto data |
+| 20 | **Oanda** | `oanda.py` | Forex | Trial | Complete | Institutional forex data |
 
 **Provider Summary**:
-- **12 Live Providers**: Real-time API access
-- **1 Historical Provider**: Wiki Prices fallback (1962-2018 survivorship-bias-free)
-- **1 Mock Provider**: Testing and offline development
-- **12 Integration Tests**: Real API validation (10 providers with positive results)
-- **Coverage**: Crypto (4), Equities (8), Forex (3), Futures (1)
+- **20 Live Providers**: 10 free + 10 authenticated/metered
+- **3 Synthetic/Testing**: SyntheticProvider, LearnedSyntheticProvider, MockProvider
+- **Coverage**: Crypto (7), Equities (7), Forex (3), Futures (1), Economic (1), Factors (2), Prediction Markets (2), Tick Data (1)
 
 #### Base Provider Infrastructure
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,24 +1,421 @@
 # API Reference
 
-Auto-generated API documentation from source code.
+Complete API documentation for the `ml4t-data` library, auto-generated from
+source docstrings via [mkdocstrings](https://mkdocstrings.github.io/).
 
-## Providers
+---
 
-::: ml4t.data.providers.base.BaseProvider
+## DataManager
+
+The primary entry point for all data operations. `DataManager` is a facade that
+delegates to focused manager classes for configuration, fetching, storage,
+metadata, and batch operations.
+
+```python
+from ml4t.data import DataManager
+
+# Fetch-only (no storage)
+manager = DataManager()
+df = manager.fetch("AAPL", "2024-01-01", "2024-12-31", provider="yahoo")
+
+# With storage for load/update workflows
+from ml4t.data.storage import HiveStorage, StorageConfig
+
+storage = HiveStorage(StorageConfig(base_path="./data"))
+manager = DataManager(storage=storage, use_transactions=True)
+key = manager.load("AAPL", "2024-01-01", "2024-12-31")
+key = manager.update("AAPL")
+```
+
+::: ml4t.data.DataManager
     options:
-      show_root_heading: true
+      show_source: false
+      heading_level: 3
       members:
-        - fetch_ohlcv
-        - capabilities
+        - __init__
+        - fetch
+        - fetch_batch
+        - batch_load
+        - batch_load_universe
+        - batch_load_from_storage
+        - load
+        - import_data
+        - update
+        - list_symbols
+        - get_metadata
+        - assign_sessions
+        - complete_sessions
+        - update_all
+        - list_providers
+        - get_provider_info
+        - clear_cache
+        - config
+        - output_format
+        - storage
 
-## Async Batch Loading
-
-::: ml4t.data.managers.async_batch
-    options:
-      show_root_heading: true
+---
 
 ## Storage
 
+### StorageConfig
+
+Dataclass configuring the storage backend. Controls partitioning strategy,
+compression, locking, and metadata tracking.
+
+```python
+from ml4t.data.storage import StorageConfig
+
+# Hive-partitioned storage for minute data
+config = StorageConfig(
+    base_path="./market_data",
+    strategy="hive",
+    partition_granularity="day",
+    compression="zstd",
+)
+
+# Flat storage for small datasets
+config = StorageConfig(
+    base_path="./data",
+    strategy="flat",
+    compression="snappy",
+)
+```
+
+::: ml4t.data.storage.backend.StorageConfig
+    options:
+      show_source: false
+      heading_level: 4
+
+### StorageBackend
+
+Abstract base class defining the storage interface. All backends (Hive, Flat)
+implement this contract.
+
+::: ml4t.data.storage.backend.StorageBackend
+    options:
+      show_source: false
+      heading_level: 4
+      members:
+        - __init__
+        - write
+        - read
+        - list_keys
+        - exists
+        - delete
+        - get_metadata
+
+### HiveStorage
+
+Hive-partitioned storage with configurable time-based partitioning. Delivers
+7x query performance improvement for time-range queries via partition pruning.
+
+```python
+from ml4t.data.storage import HiveStorage, StorageConfig
+
+config = StorageConfig(
+    base_path="./data",
+    partition_granularity="month",  # year, month, day, or hour
+)
+storage = HiveStorage(config)
+
+# Write data (partitions by timestamp automatically)
+storage.write(df, "equities/daily/AAPL")
+
+# Read with partition pruning
+from datetime import datetime
+lf = storage.read(
+    "equities/daily/AAPL",
+    start_date=datetime(2024, 6, 1),
+    end_date=datetime(2024, 12, 31),
+    columns=["timestamp", "close", "volume"],
+)
+df = lf.collect()
+```
+
 ::: ml4t.data.storage.hive.HiveStorage
     options:
-      show_root_heading: true
+      show_source: false
+      heading_level: 4
+      members:
+        - __init__
+        - write
+        - read
+        - list_keys
+        - exists
+        - delete
+        - get_latest_timestamp
+        - save_chunk
+        - update_combined_file
+        - read_data
+        - update_metadata
+
+### FlatStorage
+
+Simple single-file-per-key storage. Suitable for smaller datasets or when
+partition pruning is not beneficial.
+
+```python
+from ml4t.data.storage import FlatStorage, StorageConfig
+
+config = StorageConfig(base_path="./data", strategy="flat")
+storage = FlatStorage(config)
+
+storage.write(df, "reference/spy")
+lf = storage.read("reference/spy")
+```
+
+::: ml4t.data.storage.flat.FlatStorage
+    options:
+      show_source: false
+      heading_level: 4
+      members:
+        - __init__
+        - write
+        - read
+        - list_keys
+        - exists
+        - delete
+
+### create_storage
+
+Factory function for creating storage backends from a strategy name.
+
+```python
+from ml4t.data.storage import create_storage
+
+storage = create_storage("./data", strategy="hive", partition_granularity="day")
+```
+
+::: ml4t.data.storage.create_storage
+    options:
+      show_source: false
+      heading_level: 4
+
+---
+
+## Providers
+
+### BaseProvider
+
+Abstract base class for all data providers. Composes rate-limiting,
+circuit-breaker, validation, and HTTP session mixins into a single base.
+
+Concrete providers implement either:
+
+- `_fetch_and_transform_data()` for a single-step workflow, or
+- `_fetch_raw_data()` + `_transform_data()` for a two-step workflow.
+
+```python
+from ml4t.data.providers.base import BaseProvider
+import polars as pl
+
+class MyProvider(BaseProvider):
+    @property
+    def name(self) -> str:
+        return "my_provider"
+
+    def _fetch_and_transform_data(self, symbol, start, end, frequency):
+        # Fetch from API and return canonical OHLCV DataFrame
+        ...
+```
+
+::: ml4t.data.providers.base.BaseProvider
+    options:
+      show_source: false
+      heading_level: 4
+      members:
+        - __init__
+        - name
+        - fetch_ohlcv
+        - fetch_ohlcv_async
+        - capabilities
+        - close
+
+### ProviderCapabilities
+
+Frozen dataclass describing what a provider supports (intraday, crypto, forex,
+futures, authentication requirements, rate limits).
+
+```python
+from ml4t.data.providers.protocols import ProviderCapabilities
+
+caps = ProviderCapabilities(
+    supports_intraday=True,
+    supports_crypto=True,
+    requires_api_key=True,
+    rate_limit=(120, 60.0),  # 120 calls per 60 seconds
+)
+```
+
+::: ml4t.data.providers.protocols.ProviderCapabilities
+    options:
+      show_source: false
+      heading_level: 4
+
+### OHLCVProvider (Protocol)
+
+Structural typing protocol for OHLCV providers. Any class implementing
+`name`, `fetch_ohlcv()`, and `capabilities()` satisfies this protocol
+without inheriting from `BaseProvider`.
+
+::: ml4t.data.providers.protocols.OHLCVProvider
+    options:
+      show_source: false
+      heading_level: 4
+
+---
+
+## Configuration
+
+### Config
+
+Pydantic model for top-level library configuration. Reads defaults from
+environment variables (`QLDM_DATA_ROOT`, `QLDM_LOG_LEVEL`).
+
+```python
+from ml4t.data import Config
+
+# Use defaults
+config = Config()
+
+# Override data root
+config = Config(data_root="/mnt/fast/market_data", log_level="DEBUG")
+```
+
+::: ml4t.data.core.config.Config
+    options:
+      show_source: false
+      heading_level: 4
+      members:
+        - __init__
+        - data_root
+        - log_level
+        - storage
+        - retry
+        - cache
+        - validation
+        - base_dir
+
+### RetryConfig
+
+Configuration for automatic retry with exponential backoff.
+
+::: ml4t.data.core.config.RetryConfig
+    options:
+      show_source: false
+      heading_level: 4
+
+### CacheConfig
+
+Configuration for in-memory caching.
+
+::: ml4t.data.core.config.CacheConfig
+    options:
+      show_source: false
+      heading_level: 4
+
+---
+
+## Exceptions
+
+All exceptions inherit from `ML4TDataError`, which carries an optional
+`details` dictionary for structured error context.
+
+```
+ML4TDataError
+├── ProviderError
+│   ├── NetworkError
+│   │   └── RateLimitError
+│   ├── AuthenticationError
+│   ├── DataValidationError
+│   ├── SymbolNotFoundError
+│   └── DataNotAvailableError
+├── StorageError
+│   └── LockError
+├── ConfigurationError
+└── CircuitBreakerOpenError
+```
+
+### ML4TDataError
+
+::: ml4t.data.core.exceptions.ML4TDataError
+    options:
+      show_source: false
+      heading_level: 4
+
+### ProviderError
+
+::: ml4t.data.core.exceptions.ProviderError
+    options:
+      show_source: false
+      heading_level: 4
+
+### NetworkError
+
+::: ml4t.data.core.exceptions.NetworkError
+    options:
+      show_source: false
+      heading_level: 4
+
+### RateLimitError
+
+::: ml4t.data.core.exceptions.RateLimitError
+    options:
+      show_source: false
+      heading_level: 4
+
+### AuthenticationError
+
+::: ml4t.data.core.exceptions.AuthenticationError
+    options:
+      show_source: false
+      heading_level: 4
+
+### DataValidationError
+
+::: ml4t.data.core.exceptions.DataValidationError
+    options:
+      show_source: false
+      heading_level: 4
+
+### SymbolNotFoundError
+
+::: ml4t.data.core.exceptions.SymbolNotFoundError
+    options:
+      show_source: false
+      heading_level: 4
+
+### DataNotAvailableError
+
+::: ml4t.data.core.exceptions.DataNotAvailableError
+    options:
+      show_source: false
+      heading_level: 4
+
+### StorageError
+
+::: ml4t.data.core.exceptions.StorageError
+    options:
+      show_source: false
+      heading_level: 4
+
+### LockError
+
+::: ml4t.data.core.exceptions.LockError
+    options:
+      show_source: false
+      heading_level: 4
+
+### ConfigurationError
+
+::: ml4t.data.core.exceptions.ConfigurationError
+    options:
+      show_source: false
+      heading_level: 4
+
+### CircuitBreakerOpenError
+
+::: ml4t.data.core.exceptions.CircuitBreakerOpenError
+    options:
+      show_source: false
+      heading_level: 4

--- a/docs/providers/fama-french.md
+++ b/docs/providers/fama-french.md
@@ -1,1 +1,0 @@
-# Fama-french Provider\n\nDocumentation coming soon.\n\nSee [providers overview](index.md) for comparison.

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -1,6 +1,6 @@
 # Providers
 
-ML4T Data supports 15 data providers with a unified API.
+ML4T Data supports 20 live data providers with a unified API (plus synthetic and testing providers).
 
 ## Provider Comparison
 
@@ -8,18 +8,24 @@ ML4T Data supports 15 data providers with a unified API.
 |----------|-------------|-----------|-------|---------|
 | [Yahoo Finance](yahoo.md) | Stocks, ETFs, Crypto | Unlimited | Thread | No |
 | [CoinGecko](coingecko.md) | Crypto | 10K+ coins | Native | No |
-| [EODHD](eodhd.md) | Global Stocks | 500/day | Native | Yes |
-| [Binance](binance.md) | Crypto | Unlimited | Native | No |
-| [TwelveData](twelve_data.md) | Multi-asset | 800/day | Native | Yes |
-| [CryptoCompare](cryptocompare.md) | Crypto | Good | Native | Optional |
-| [DataBento](databento.md) | Futures, Options | $10 credits | Thread | Yes |
-| [Tiingo](tiingo.md) | US Stocks | 1000/day | Thread | Yes |
-| [Finnhub](finnhub.md) | Global Stocks | 30/day OHLCV | Thread | Yes |
-| [Polygon](polygon.md) | Multi-asset | Paid only | Thread | Yes |
-| [Oanda](oanda.md) | Forex | Demo only | Thread | Yes |
-| [Fama-French](fama-french.md) | Factors | Unlimited | Thread | No |
+| [FRED](fred.md) | Economic Data | 120/min | Thread | Yes |
+| [Fama-French](fama_french.md) | Factors | Unlimited | Thread | No |
 | [AQR](aqr.md) | Factors | Unlimited | Thread | No |
-| [Wiki Prices](wiki-prices.md) | Historical | Static | Thread | No |
+| [Wiki Prices](wiki_prices.md) | Historical | Static | Thread | No |
+| [Kalshi](kalshi.md) | Prediction Markets | Public data | Thread | No |
+| [Polymarket](polymarket.md) | Prediction Markets | Public data | Thread | No |
+| [Binance Public](binance_public.md) | Crypto | Bulk downloads | Thread | No |
+| [NASDAQ ITCH](nasdaq_itch.md) | Tick Data | Sample data | Thread | No |
+| [EODHD](eodhd.md) | Global Stocks | 500/day | Native | Yes |
+| [Tiingo](tiingo.md) | US Stocks | 1000/day | Thread | Yes |
+| [TwelveData](twelve_data.md) | Multi-asset | 800/day | Native | Yes |
+| [DataBento](databento.md) | Futures, Options | $10 credits | Thread | Yes |
+| [Polygon](polygon.md) | Multi-asset | Paid only | Thread | Yes |
+| [Finnhub](finnhub.md) | Global Stocks | 30/day OHLCV | Thread | Yes |
+| [Binance](binance.md) | Crypto | Unlimited | Native | No |
+| [OKX](okx.md) | Crypto Perpetuals | No geo-limits | Native | No |
+| [CryptoCompare](cryptocompare.md) | Crypto | Good | Native | Optional |
+| [Oanda](oanda.md) | Forex | Demo only | Thread | Yes |
 
 ## Async Support
 

--- a/docs/providers/okx.md
+++ b/docs/providers/okx.md
@@ -1,0 +1,70 @@
+# OKX Provider
+
+**Provider**: `OKXProvider`
+**Website**: [okx.com](https://www.okx.com)
+**API Key**: Not required for public market data
+**Free Tier**: No geo-restrictions
+
+---
+
+## Overview
+
+OKX provides cryptocurrency perpetual swap data with funding rates. Unlike Binance, OKX has no geo-restrictions, making it accessible globally.
+
+**Best For**: Crypto perpetuals, funding rate analysis
+
+---
+
+## Quick Start
+
+```python
+from ml4t.data.providers import OKXProvider
+
+provider = OKXProvider()
+
+# Perpetual swap OHLCV
+df = provider.fetch_ohlcv("BTC-USDT-SWAP", "2024-01-01", "2024-06-30", frequency="daily")
+
+# Funding rates
+rates = provider.fetch_funding_rates("BTC-USDT-SWAP", "2024-01-01", "2024-06-30")
+
+provider.close()
+```
+
+---
+
+## Symbol Format
+
+| Type | Format | Examples |
+|------|--------|----------|
+| Perpetual Swap | BASE-QUOTE-SWAP | BTC-USDT-SWAP, ETH-USDT-SWAP |
+
+---
+
+## Supported Frequencies
+
+| Frequency | Available |
+|-----------|-----------|
+| `1m` | Yes |
+| `5m` | Yes |
+| `15m` | Yes |
+| `1h` | Yes |
+| `daily` | Yes |
+
+---
+
+## Async Support
+
+OKX uses native async via `httpx.AsyncClient`:
+
+```python
+async with OKXProvider() as provider:
+    df = await provider.fetch_ohlcv_async("BTC-USDT-SWAP", "2024-01-01", "2024-06-30")
+```
+
+---
+
+## See Also
+
+- [OKX API v5 Documentation](https://www.okx.com/docs-v5/en/)
+- [Provider README](README.md)

--- a/docs/providers/wiki-prices.md
+++ b/docs/providers/wiki-prices.md
@@ -1,1 +1,0 @@
-# Wiki-prices Provider\n\nDocumentation coming soon.\n\nSee [providers overview](index.md) for comparison.

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -1,1 +1,228 @@
-# CLI Reference\n\nSee [main documentation](../README.md) for CLI details.
+# CLI Reference
+
+The `ml4t-data` command-line tool provides unified access to data fetching, storage
+management, validation, and system administration. All commands support `--verbose`
+and `--quiet` flags for output control.
+
+```bash
+ml4t-data [--verbose | --quiet] <command> [options]
+```
+
+## Core Commands
+
+### fetch
+
+Fetch financial data from any configured provider.
+
+```bash
+# Single symbol
+ml4t-data fetch -s AAPL --start 2024-01-01 --end 2024-12-31
+
+# Multiple symbols
+ml4t-data fetch -s BTC -s ETH --start 2024-01-01 --end 2024-06-30
+
+# From a symbols file (one symbol per line)
+ml4t-data fetch -f symbols.txt --start 2024-01-01 --end 2024-12-31
+
+# Specific provider and frequency
+ml4t-data fetch -s AAPL --provider yahoo --frequency daily \
+    --start 2024-01-01 --end 2024-12-31
+
+# Save output to file
+ml4t-data fetch -s AAPL --start 2024-01-01 --end 2024-12-31 -o data.parquet
+
+# Show progress bar for batch fetches
+ml4t-data fetch -f sp500.txt --start 2024-01-01 --end 2024-12-31 --progress
+```
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--symbol` | `-s` | Symbol(s) to fetch (repeatable) |
+| `--symbols-file` | `-f` | File containing symbols, one per line |
+| `--start` | | Start date (YYYY-MM-DD), required |
+| `--end` | | End date (YYYY-MM-DD), required |
+| `--frequency` | | `daily`, `hourly`, or `weekly` (default: `daily`) |
+| `--provider` | `-p` | Specific provider to use |
+| `--output` | `-o` | Output file path (.parquet or .csv) |
+| `--config` | `-c` | JSON configuration file |
+| `--progress` | | Show progress bar for batch fetches |
+
+### update
+
+Perform incremental data updates for symbols already in storage.
+
+```bash
+# Incremental update (default - only fetches new data)
+ml4t-data update -s AAPL --storage-path ./data
+
+# Full refresh
+ml4t-data update -s AAPL --strategy full_refresh --storage-path ./data
+
+# Backfill with specific date range
+ml4t-data update -s AAPL --strategy backfill \
+    --start 2020-01-01 --end 2020-12-31 --storage-path ./data
+```
+
+| Option | Description |
+|--------|-------------|
+| `--symbol`, `-s` | Symbol to update (required) |
+| `--start` | Start date (defaults to 30 days ago) |
+| `--end` | End date (defaults to today) |
+| `--strategy` | `incremental`, `append_only`, `full_refresh`, or `backfill` |
+| `--provider`, `-p` | Provider to use for fetching |
+| `--storage-path` | Storage directory (default: `./data`) |
+
+### validate
+
+Validate data quality and integrity. Checks OHLC relationships, duplicates,
+and optionally runs anomaly detection.
+
+```bash
+# Validate a single symbol
+ml4t-data validate -s AAPL --storage-path ./data
+
+# Validate all stored symbols
+ml4t-data validate --all --storage-path ./data
+
+# Include anomaly detection
+ml4t-data validate -s AAPL --anomalies --storage-path ./data
+
+# Filter by severity and save report
+ml4t-data validate -s AAPL --anomalies --severity error --save-report
+```
+
+| Option | Description |
+|--------|-------------|
+| `--symbol`, `-s` | Symbol to validate |
+| `--all` | Validate all symbols in storage |
+| `--anomalies` | Run anomaly detection (return outliers, volume spikes, staleness) |
+| `--save-report` | Save anomaly report to `./anomaly_reports/` |
+| `--severity` | Minimum severity: `info`, `warning`, `error`, `critical` |
+| `--storage-path` | Storage directory (default: `./data`) |
+
+### status
+
+Show system overview and health status of stored datasets.
+
+```bash
+ml4t-data status --storage-path ./data
+ml4t-data status --detailed --storage-path ./data
+```
+
+The `--detailed` flag shows per-symbol panels with provider, frequency, row count,
+date range, last update, and health status.
+
+### export
+
+Export stored data to CSV, JSON, or Parquet.
+
+```bash
+ml4t-data export -s AAPL -o aapl.csv --format csv
+ml4t-data export -s AAPL -o aapl.json --format json
+ml4t-data export -s AAPL -o aapl.parquet --format parquet
+```
+
+### list
+
+List all stored datasets, organized by provider type.
+
+```bash
+ml4t-data list --config ml4t-data.yaml
+ml4t-data list --storage-path ./data
+```
+
+Requires either `--config` (YAML file with `storage.path`) or `--storage-path`.
+
+### info
+
+Show detailed information about a specific stored symbol, including a data preview.
+
+```bash
+ml4t-data info -s AAPL --storage-path ./data
+```
+
+## Batch Operations
+
+### update-all
+
+Update all datasets defined in a YAML configuration file.
+
+```bash
+# Update everything
+ml4t-data update-all -c ml4t-data.yaml
+
+# Update a specific dataset group
+ml4t-data update-all -c ml4t-data.yaml --dataset futures
+
+# Preview what would be updated
+ml4t-data update-all -c ml4t-data.yaml --dry-run
+```
+
+The configuration file defines datasets with inline symbols or file references:
+
+```yaml
+storage:
+  path: ~/ml4t-data
+
+datasets:
+  equities:
+    provider: yahoo
+    symbols: [AAPL, MSFT, GOOGL]
+  sp500:
+    provider: yahoo
+    symbols_file: sp500.txt
+```
+
+## Futures Commands
+
+### download-futures
+
+Download historical futures data from Databento (requires API key).
+
+```bash
+ml4t-data download-futures -c futures-config.yaml
+ml4t-data download-futures -c futures-config.yaml --dry-run   # cost estimate only
+ml4t-data download-futures -c futures-config.yaml -p ES -p NQ  # specific products
+ml4t-data download-futures -c futures-config.yaml -j 4          # parallel downloads
+```
+
+### update-futures
+
+Update existing futures data with the latest available bars.
+
+### download-cot
+
+Download CFTC Commitment of Traders data.
+
+```bash
+ml4t-data download-cot -p ES -p CL --start-year 2020
+ml4t-data download-cot --list-products          # show available product codes
+ml4t-data download-cot -c cot-config.yaml -o ~/ml4t-data/cot
+```
+
+## System Commands
+
+| Command | Description |
+|---------|-------------|
+| `ml4t-data version` | Show version and Python information |
+| `ml4t-data providers` | List available data providers with API key requirements |
+| `ml4t-data config` | Show current configuration |
+| `ml4t-data health` | Check health status of all datasets |
+| `ml4t-data health --detailed --stale-days 7` | Show per-symbol staleness |
+| `ml4t-data server --port 8000` | Start the REST API server (requires `ml4t-data[api]`) |
+| `ml4t-data show-completion bash` | Print shell completion script |
+
+## Shell Completion
+
+Enable tab completion for your shell:
+
+```bash
+# Bash
+eval "$(_ML4T_DATA_COMPLETE=bash_source ml4t-data)"
+
+# Zsh
+eval "$(_ML4T_DATA_COMPLETE=zsh_source ml4t-data)"
+
+# Fish
+eval (env _ML4T_DATA_COMPLETE=fish_source ml4t-data)
+```

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -1,1 +1,258 @@
-# Configuration\n\nSee [YAML configuration guide](../README.md#configuration-file) for details.
+# Configuration
+
+ml4t-data uses YAML configuration files validated by Pydantic models. The config
+system supports environment variable interpolation, file includes, and
+per-asset-class defaults.
+
+## File Discovery
+
+The `ConfigLoader` searches these locations in order:
+
+1. `./ml4t.data.yaml`
+2. `./ml4t.data.yml`
+3. `./.ml4t-data.yaml`
+4. `./.ml4t-data.yml`
+5. `./config/ml4t.data.yaml`
+6. `~/.config/ml4t-data/config.yaml`
+
+You can also pass an explicit path:
+
+```python
+from ml4t.data.config import load_config
+
+config = load_config(Path("my-config.yaml"))
+```
+
+## Full Configuration Example
+
+```yaml
+version: "1.0"
+base_dir: ./data
+log_level: INFO
+parallel_downloads: 4
+
+# Storage backend
+storage:
+  strategy: hive            # "hive" (partitioned) or "flat" (single file)
+  base_path: ~/ml4t-data
+  compression: zstd         # zstd, lz4, snappy, or none
+  partition_granularity: month  # year, month, day, or hour
+  atomic_writes: true
+  enable_locking: true
+  metadata_tracking: true
+
+# Data providers
+providers:
+  - name: yahoo
+    type: yahoo
+    enabled: true
+    rate_limit:
+      requests_per_second: 5.0
+      retry_max_attempts: 3
+    timeout: 30
+
+  - name: databento
+    type: databento
+    api_key: ${DATABENTO_API_KEY}
+    rate_limit:
+      requests_per_second: 10.0
+      circuit_breaker_threshold: 5
+      circuit_breaker_timeout: 60
+
+# Symbol universes
+universes:
+  - name: tech_stocks
+    symbols: [AAPL, MSFT, GOOGL, AMZN, META]
+    asset_class: equity
+
+  - name: sp500
+    file: symbols/sp500.txt   # one symbol per line
+    provider: yahoo
+    asset_class: equity
+
+# Datasets
+datasets:
+  - name: us_equities
+    universe: sp500
+    provider: yahoo
+    frequency: daily
+    asset_class: equity
+    update_mode: incremental
+    validation_enabled: true
+    anomaly_detection: false
+
+  - name: crypto_spot
+    symbols: [BTC, ETH, SOL]
+    provider: binance
+    frequency: hourly
+    asset_class: crypto
+
+# Workflows
+workflows:
+  - name: daily_update
+    datasets: [us_equities, crypto_spot]
+    schedule:
+      type: daily
+      time: "18:00"
+      timezone: US/Eastern
+    on_error: continue
+```
+
+## Environment Variables
+
+API keys and secrets support `${VAR}` interpolation with optional defaults:
+
+```yaml
+providers:
+  - name: polygon
+    api_key: ${POLYGON_API_KEY}           # required
+    api_secret: ${POLYGON_SECRET:default}  # with fallback
+```
+
+The `env` section defines variables that are set if not already present:
+
+```yaml
+env:
+  ML4T_DATA_DIR: ~/ml4t-data
+  DEFAULT_PROVIDER: yahoo
+```
+
+ml4t-data also reads `.env` files automatically via Pydantic Settings.
+
+## Key Configuration Sections
+
+### Storage
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `strategy` | `hive` | `hive` for partitioned Parquet, `flat` for single files |
+| `base_path` | `./data` | Base directory (supports `~` expansion) |
+| `compression` | `zstd` | Parquet compression: `zstd`, `lz4`, `snappy`, `none` |
+| `partition_granularity` | `month` | Hive partition level: `year`, `month`, `day`, `hour` |
+| `atomic_writes` | `true` | Write to temp file then rename |
+| `enable_locking` | `true` | File locking for concurrent access |
+| `metadata_tracking` | `true` | JSON manifest files alongside data |
+
+### Providers
+
+Each provider entry configures connection parameters:
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `name` | required | Provider identifier |
+| `type` | required | `yahoo`, `binance`, `cryptocompare`, `databento`, `oanda`, `polygon`, `mock` |
+| `enabled` | `true` | Toggle provider on/off |
+| `api_key` | `null` | API key (use `${ENV_VAR}` format) |
+| `rate_limit` | see below | Rate limiting and circuit breaker config |
+| `timeout` | `30` | Request timeout in seconds |
+| `cache_enabled` | `true` | Response caching |
+| `cache_ttl` | `3600` | Cache time-to-live in seconds |
+
+Rate limiting sub-config:
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `requests_per_second` | `10.0` | Maximum request rate |
+| `burst_size` | `1` | Burst allowance |
+| `retry_max_attempts` | `3` | Retry count |
+| `retry_backoff_factor` | `2.0` | Exponential backoff multiplier |
+| `circuit_breaker_threshold` | `5` | Failures before circuit opens |
+| `circuit_breaker_timeout` | `60` | Seconds before circuit half-opens |
+
+### Schedules
+
+Workflows support five schedule types:
+
+```yaml
+# Cron expression
+schedule:
+  type: cron
+  cron: "0 18 * * 1-5"
+
+# Fixed interval (seconds)
+schedule:
+  type: interval
+  interval: 3600
+
+# Daily at specific time
+schedule:
+  type: daily
+  time: "18:00"
+  timezone: US/Eastern
+
+# Weekly
+schedule:
+  type: weekly
+  time: "09:00"
+  weekday: 0  # Monday
+
+# Relative to market hours
+schedule:
+  type: market_hours
+  market_close_offset: 30  # 30 minutes before close
+```
+
+## File Includes
+
+Split large configs across files with the `include` directive:
+
+```yaml
+# ml4t.data.yaml
+include:
+  - providers/yahoo.yaml
+  - providers/databento.yaml
+  - universes/equities.yaml
+
+datasets:
+  - name: us_equities
+    universe: sp500
+    provider: yahoo
+```
+
+Included files are merged recursively. The main file takes priority over includes.
+
+## Validation
+
+Use `ConfigValidator` to check for consistency errors before running:
+
+```python
+from ml4t.data.config import load_config, ConfigValidator
+
+config = load_config()
+validator = ConfigValidator(config)
+
+if not validator.validate():
+    for error in validator.errors:
+        print(f"ERROR: {error}")
+    for warning in validator.warnings:
+        print(f"WARNING: {warning}")
+```
+
+The validator checks for:
+
+- Duplicate provider, dataset, or universe names
+- Datasets referencing non-existent providers or universes
+- Workflows referencing non-existent datasets
+- Invalid date ranges (start >= end)
+- Missing cron expressions or interval values in schedules
+- Orphaned providers or datasets not used by any workflow
+
+## Programmatic Access
+
+```python
+from ml4t.data.config import DataConfig
+
+# Load from YAML
+config = DataConfig.from_yaml("ml4t.data.yaml")
+
+# Look up components
+provider = config.get_provider("yahoo")
+universe = config.get_universe("sp500")
+dataset = config.get_dataset("us_equities")
+
+# Validate references
+issues = config.validate_config()
+
+# Save back to YAML
+config.to_yaml("ml4t.data.yaml")
+```

--- a/docs/user-guide/data-quality.md
+++ b/docs/user-guide/data-quality.md
@@ -1,1 +1,231 @@
-# Data Quality\n\nML4T Data includes comprehensive data quality features.\n\n## OHLC Validation\n\nAll data is validated against OHLC invariants:\n\n- High >= Low\n- High >= Open, Close\n- Low <= Open, Close\n- Volume >= 0\n\n## Anomaly Detection\n\nSee [anomaly detection guide](../tutorials/04_data_quality.md).
+# Data Quality
+
+ml4t-data provides two complementary quality systems: **OHLCV validation** for
+structural correctness checks, and **anomaly detection** for statistical
+pattern analysis. Both can be run from code or through the CLI.
+
+## OHLCV Validation
+
+The `OHLCVValidator` performs eight configurable checks on any DataFrame with
+standard OHLCV columns (`timestamp`, `open`, `high`, `low`, `close`, `volume`).
+
+### Checks Performed
+
+| Check | Severity | What it catches |
+|-------|----------|-----------------|
+| Null values | ERROR | Missing prices or volume in any OHLCV column |
+| Price consistency | ERROR | `high < low`, `high < open`, `low > close`, etc. |
+| Negative prices | CRITICAL | Any OHLC value below zero |
+| Negative volume | ERROR | Volume below zero |
+| Duplicate timestamps | ERROR | Multiple rows with the same timestamp |
+| Chronological order | ERROR | Timestamps not sorted ascending |
+| Price staleness | WARNING | Close price unchanged for N+ consecutive days |
+| Extreme returns | WARNING | Single-period return exceeding threshold |
+
+### Usage
+
+```python
+from ml4t.data.validation import OHLCVValidator
+
+# Default settings
+validator = OHLCVValidator()
+result = validator.validate(df)
+
+if not result.passed:
+    for issue in result.issues:
+        print(f"[{issue.severity}] {issue.check}: {issue.message}")
+
+# Customize thresholds
+validator = OHLCVValidator(
+    max_return_threshold=0.3,    # flag returns > 30%
+    staleness_threshold=10,      # flag 10+ unchanged days
+    check_extreme_returns=False, # disable return checks entirely
+)
+```
+
+Each `ValidationIssue` includes the check name, severity, affected row count,
+and up to 10 sample row indices for debugging.
+
+### Validation Rules and Presets
+
+For different asset classes, use the built-in presets which adjust thresholds
+to match expected behavior:
+
+```python
+from ml4t.data.validation.rules import ValidationRulePresets
+
+# Crypto is more volatile - wider thresholds
+crypto_rules = ValidationRulePresets.crypto_rules()
+# max_return_threshold=0.5, staleness_threshold=3, no market hours check
+
+# Forex is less volatile - tighter thresholds
+forex_rules = ValidationRulePresets.forex_rules()
+# max_return_threshold=0.1, staleness_threshold=10, 24/5 market
+
+# Strict mode for production data
+strict_rules = ValidationRulePresets.strict_rules()
+# max_return_threshold=0.1, staleness_threshold=3, all checks enabled
+```
+
+Available presets: `equity_rules()`, `crypto_rules()`, `forex_rules()`,
+`commodity_rules()`, `strict_rules()`, `relaxed_rules()`.
+
+### Persistent Rule Sets
+
+Save and load validation rules per symbol or pattern:
+
+```python
+from ml4t.data.validation.rules import ValidationRuleSet, ValidationRulePresets
+
+ruleset = ValidationRuleSet(name="production")
+ruleset.default_rule = ValidationRulePresets.equity_rules()
+ruleset.add_rule("BTC*", ValidationRulePresets.crypto_rules())
+ruleset.add_rule("EUR*", ValidationRulePresets.forex_rules())
+
+# Save to YAML
+ruleset.save(Path("validation_rules.yaml"))
+
+# Load later
+ruleset = ValidationRuleSet.load(Path("validation_rules.yaml"))
+rules = ruleset.get_rules("BTCUSD")  # matches "BTC*" pattern
+```
+
+## Anomaly Detection
+
+The anomaly detection system uses statistical methods to find data quality
+issues that pass basic validation but indicate potential problems.
+
+### Built-in Detectors
+
+**ReturnOutlierDetector** -- flags unusually large price moves.
+
+- Methods: MAD (default), z-score, IQR
+- MAD is robust to fat tails common in financial data
+- Severity scales with magnitude: INFO (3x) to CRITICAL (5x+)
+
+**VolumeSpikeDetector** -- flags unusual volume relative to a rolling baseline.
+
+- Uses rolling z-score over a configurable window (default: 20 bars)
+- Filters out low-volume noise with a minimum volume threshold
+
+**PriceStalenessDetector** -- flags periods where prices do not change.
+
+- Can check close-only or all OHLC prices
+- Severity scales with duration: INFO (5 days) to CRITICAL (20+ days)
+- Groups consecutive unchanged periods to avoid duplicate alerts
+
+### Running Anomaly Detection
+
+```python
+from ml4t.data.anomaly import AnomalyManager, AnomalyConfig
+
+# Default configuration (all detectors enabled)
+manager = AnomalyManager()
+report = manager.analyze(df, symbol="AAPL")
+
+print(f"Found {len(report.anomalies)} anomalies")
+for anomaly in report.anomalies:
+    print(anomaly)
+    # [WARNING] AAPL @ 2024-03-15: Unusual return of -8.42% (MAD z-score: 3.21)
+
+# Check for critical issues
+if report.has_critical_issues():
+    print("Critical data quality issues found!")
+
+# Convert to DataFrame for analysis
+anomaly_df = report.to_dataframe()
+```
+
+### Custom Configuration
+
+```python
+from ml4t.data.anomaly import AnomalyConfig
+from ml4t.data.anomaly.config import (
+    ReturnOutlierConfig,
+    VolumeSpikeConfig,
+    PriceStalenessConfig,
+)
+
+config = AnomalyConfig(
+    return_outliers=ReturnOutlierConfig(
+        method="mad",       # "mad", "zscore", or "iqr"
+        threshold=4.0,      # stricter than default 3.0
+        min_samples=50,
+    ),
+    volume_spikes=VolumeSpikeConfig(
+        window=30,           # 30-day rolling baseline
+        threshold=4.0,
+        min_volume=1000,     # ignore low-volume days
+    ),
+    price_staleness=PriceStalenessConfig(
+        max_unchanged_days=3,
+        check_close_only=True,
+    ),
+)
+
+manager = AnomalyManager(config=config)
+```
+
+### Asset-Class and Symbol Overrides
+
+The config supports per-asset-class and per-symbol threshold overrides:
+
+```python
+config = AnomalyConfig(
+    asset_overrides={
+        "crypto": {
+            "return_outliers": {"threshold": 5.0},  # crypto is volatile
+            "price_staleness": {"max_unchanged_days": 2},
+        }
+    },
+    symbol_overrides={
+        "BTCUSD": {
+            "return_outliers": {"threshold": 6.0},  # BTC even more volatile
+        }
+    },
+)
+
+manager = AnomalyManager(config=config)
+report = manager.analyze(df, symbol="BTCUSD", asset_class="crypto")
+```
+
+### Batch Analysis and Reports
+
+```python
+# Analyze multiple symbols
+datasets = {"AAPL": df_aapl, "MSFT": df_msft, "GOOGL": df_googl}
+reports = manager.analyze_batch(datasets)
+
+# Save reports to disk
+for symbol, report in reports.items():
+    if report.anomalies:
+        manager.save_report(report, Path("./anomaly_reports"))
+
+# Filter by severity
+filtered = manager.filter_by_severity(report, min_severity="warning")
+
+# Get statistics
+stats = manager.get_statistics(report)
+# {"total_anomalies": 12, "by_severity": {"warning": 8, "error": 3, ...}, ...}
+```
+
+### CLI Integration
+
+Run validation and anomaly detection together from the command line:
+
+```bash
+# Basic validation
+ml4t-data validate -s AAPL --storage-path ./data
+
+# With anomaly detection
+ml4t-data validate -s AAPL --anomalies --storage-path ./data
+
+# Filter noise -- only show errors and critical
+ml4t-data validate --all --anomalies --severity error --storage-path ./data
+
+# Save anomaly reports for later review
+ml4t-data validate --all --anomalies --save-report --storage-path ./data
+```
+
+The CLI returns exit code 1 if any issues are found, making it suitable for
+CI pipelines and pre-processing checks.

--- a/docs/user-guide/storage.md
+++ b/docs/user-guide/storage.md
@@ -1,1 +1,240 @@
-# Storage\n\nML4T Data uses Hive-partitioned Parquet storage.\n\nSee [storage documentation](../storage/PARTITIONING_GUIDE.md).
+# Storage
+
+ml4t-data stores time-series data as Parquet files with two backend strategies:
+**Hive** (partitioned by time) and **Flat** (single file per key). Both backends
+share atomic writes, file locking, metadata tracking, and Polars lazy evaluation.
+
+## Choosing a Backend
+
+| | Hive | Flat |
+|---|------|------|
+| **Best for** | Large datasets, time-range queries | Small datasets, simple access |
+| **Layout** | Directory tree with `year=.../month=.../data.parquet` | Single `.parquet` file per key |
+| **Query speed** | 7x faster for date-filtered reads (partition pruning) | Reads entire file every time |
+| **Write cost** | Higher (one file per partition) | Lower (single file) |
+| **Default** | Yes | No |
+
+```python
+from ml4t.data.storage import create_storage
+
+# Hive storage (default)
+storage = create_storage("./data", strategy="hive")
+
+# Flat storage
+storage = create_storage("./data", strategy="flat")
+```
+
+## Partition Granularity
+
+Hive storage partitions data by time. Choose granularity based on your data
+frequency to keep partition sizes in the 200-5,000 row range:
+
+| Granularity | Partition columns | Best for | Rows/partition (stocks) |
+|-------------|-------------------|----------|------------------------|
+| `year` | `year/` | Daily data | ~252 |
+| `month` | `year=/month=/` | Hourly data | ~720 |
+| `day` | `year=/month=/day=/` | Minute data | ~1,440 |
+| `hour` | `year=/month=/day=/hour=/` | Second/tick data | ~3,600 |
+
+```python
+from ml4t.data.storage import HiveStorage, StorageConfig
+
+# Daily equity data -- partition by year
+config = StorageConfig(
+    base_path="./data",
+    partition_granularity="year",
+)
+storage = HiveStorage(config)
+
+# Minute crypto data -- partition by day
+config = StorageConfig(
+    base_path="./data",
+    partition_granularity="day",
+)
+storage = HiveStorage(config)
+```
+
+On-disk layout for month-level partitioning:
+
+```
+data/
+  AAPL/
+    year=2024/
+      month=1/
+        data.parquet
+      month=2/
+        data.parquet
+      ...
+    year=2025/
+      month=1/
+        data.parquet
+  .metadata/
+    AAPL.json
+```
+
+## Reading and Writing
+
+Both backends use the same `StorageBackend` interface.
+
+### Writing Data
+
+```python
+import polars as pl
+
+df = pl.DataFrame({
+    "timestamp": [...],
+    "open": [...],
+    "high": [...],
+    "low": [...],
+    "close": [...],
+    "volume": [...],
+})
+
+# Write with a storage key
+storage.write(df, "AAPL")
+```
+
+The write operation:
+
+1. Adds partition columns derived from `timestamp` (Hive only)
+2. Groups data by partition values
+3. Writes each partition atomically (temp file + rename)
+4. Updates the JSON metadata manifest
+
+### Reading Data
+
+All reads return a Polars `LazyFrame` for deferred execution:
+
+```python
+# Read all data for a key
+lf = storage.read("AAPL")
+df = lf.collect()
+
+# Date-filtered read (Hive prunes partitions before scanning)
+from datetime import datetime
+
+lf = storage.read(
+    "AAPL",
+    start_date=datetime(2024, 6, 1),
+    end_date=datetime(2024, 12, 31),
+)
+
+# Column projection (only read what you need)
+lf = storage.read("AAPL", columns=["timestamp", "close", "volume"])
+```
+
+With Hive storage, date filters prune entire partition directories before
+any Parquet file is opened, giving measured 7x speedup on typical queries.
+
+### Other Operations
+
+```python
+# List all stored keys
+keys = storage.list_keys()  # ["AAPL", "BTC-USD", ...]
+
+# Check existence
+if storage.exists("AAPL"):
+    ...
+
+# Delete all data for a key
+storage.delete("AAPL")
+
+# Read metadata
+meta = storage.get_metadata("AAPL")
+# {"last_updated": "...", "row_count": 5040, "schema": [...], ...}
+```
+
+## StorageConfig Options
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `base_path` | required | Base directory for all data |
+| `strategy` | `"hive"` | `"hive"` or `"flat"` |
+| `compression` | `"zstd"` | Parquet compression: `zstd`, `lz4`, `snappy`, or `None` |
+| `partition_granularity` | `"month"` | `year`, `month`, `day`, `hour` (Hive only) |
+| `atomic_writes` | `True` | Write to temp file then rename |
+| `enable_locking` | `True` | File locking for concurrent access |
+| `metadata_tracking` | `True` | JSON manifest files in `.metadata/` |
+| `generate_profile` | `True` | Column-level statistics on write |
+
+## Incremental Updates
+
+Hive storage supports chunk-based incremental updates for streaming workflows:
+
+```python
+from datetime import datetime
+
+# Save a new data chunk
+chunk_path = storage.save_chunk(
+    data=new_df,
+    symbol="AAPL",
+    provider="yahoo",
+    start_time=datetime(2024, 12, 1),
+    end_time=datetime(2024, 12, 31),
+)
+
+# Merge chunk into the main combined file (deduplicates by timestamp)
+new_rows = storage.update_combined_file(new_df, symbol="AAPL", provider="yahoo")
+
+# Get latest timestamp for a symbol (to know where to resume)
+latest = storage.get_latest_timestamp("AAPL", "yahoo")
+```
+
+## Data Profiling
+
+The `ProfileMixin` adds dataset profiling to any data manager class.
+Profiles contain column-level statistics (dtype, null count, min/max, mean, std)
+stored as JSON alongside the data.
+
+```python
+from ml4t.data.storage import generate_profile, save_profile, load_profile
+
+# Generate a profile from a DataFrame
+profile = generate_profile(df, source="ETFDataManager")
+print(profile.summary())
+# Dataset Profile (generated: 2024-12-15T10:30:00)
+#   Rows: 25,200
+#   Columns: 7
+#   Date range: 2020-01-02 to 2024-12-13
+#   Column Details:
+#     close: Float64 (25200 unique, 0.0% null) [mean=156.3, std=42.1]
+#     volume: Int64 (24891 unique, 0.0% null) [mean=7.83e+07, std=4.21e+07]
+
+# Save and load profiles
+save_profile(profile, Path("data/AAPL_profile.json"))
+profile = load_profile(Path("data/AAPL_profile.json"))
+
+# Convert to DataFrame for analysis
+profile_df = profile.to_dataframe()
+```
+
+To add profiling to a custom data manager, implement the `ProfileMixin`:
+
+```python
+from ml4t.data.storage import ProfileMixin
+
+class MyDataManager(ProfileMixin):
+    def _get_profile_data(self) -> pl.DataFrame:
+        return self.load_all()
+
+    def _get_profile_data_path(self) -> Path:
+        return self.storage_path / "data.parquet"
+
+    def _get_profile_source_name(self) -> str:
+        return "MyDataManager"
+
+# Now available:
+profile = manager.generate_profile()  # generates and saves
+profile = manager.load_profile()      # loads existing
+```
+
+## Concurrency and Safety
+
+Both backends use two mechanisms for safe concurrent access:
+
+- **Atomic writes**: Data is written to a temporary file first, then renamed
+  to the target path. This prevents readers from seeing partial writes.
+- **File locking**: Metadata updates use `filelock` to prevent corruption
+  when multiple processes write simultaneously. Lock timeout is 10 seconds.
+
+These are enabled by default and can be toggled via `StorageConfig`.

--- a/docs/wiki_prices_status.md
+++ b/docs/wiki_prices_status.md
@@ -44,7 +44,7 @@ The **Wiki Prices dataset is DEPRECATED and no longer maintained** as of April 1
 ### 3. Local ML4T Copy
 
 **Status**: 🟢 Available (production-ready)
-**Location**: `/home/stefan/ml4t/software/projects/daily_us_equities/wiki_prices.parquet`
+**Location**: User-configured path (e.g., `~/ml4t-data/wiki_prices.parquet`)
 **File Size**: 631.7 MB
 **Format**: Polars-compatible Parquet
 
@@ -286,7 +286,7 @@ import polars as pl
 from pathlib import Path
 
 # Load from local archive
-wiki_file = Path("/home/stefan/ml4t/software/projects/daily_us_equities/wiki_prices.parquet")
+wiki_file = Path("~/ml4t-data/wiki_prices.parquet").expanduser()
 df = pl.read_parquet(wiki_file)
 
 # Filter by symbol and date
@@ -322,8 +322,8 @@ class WikiPricesProvider(BaseProvider):
     def __init__(self, parquet_path: str = None):
         super().__init__(rate_limit=None)  # Local file, no rate limit
         self.parquet_path = parquet_path or Path(
-            "/home/stefan/ml4t/software/projects/daily_us_equities/wiki_prices.parquet"
-        )
+            "~/ml4t-data/wiki_prices.parquet"
+        ).expanduser()
         # Load once and cache in memory (632MB is acceptable)
         self._data = pl.read_parquet(self.parquet_path)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -137,19 +137,25 @@ nav:
   - Providers:
     - providers/index.md
     - Yahoo Finance: providers/yahoo.md
-    - EODHD: providers/eodhd.md
-    - Binance: providers/binance.md
     - CoinGecko: providers/coingecko.md
-    - DataBento: providers/databento.md
-    - Tiingo: providers/tiingo.md
-    - TwelveData: providers/twelve_data.md
-    - CryptoCompare: providers/cryptocompare.md
-    - Finnhub: providers/finnhub.md
-    - Polygon: providers/polygon.md
-    - Oanda: providers/oanda.md
+    - FRED: providers/fred.md
     - Fama-French: providers/fama_french.md
     - AQR: providers/aqr.md
     - Wiki Prices: providers/wiki_prices.md
+    - Kalshi: providers/kalshi.md
+    - Polymarket: providers/polymarket.md
+    - Binance Public: providers/binance_public.md
+    - NASDAQ ITCH: providers/nasdaq_itch.md
+    - EODHD: providers/eodhd.md
+    - Tiingo: providers/tiingo.md
+    - TwelveData: providers/twelve_data.md
+    - DataBento: providers/databento.md
+    - Polygon: providers/polygon.md
+    - Finnhub: providers/finnhub.md
+    - Binance: providers/binance.md
+    - OKX: providers/okx.md
+    - CryptoCompare: providers/cryptocompare.md
+    - Oanda: providers/oanda.md
 
   - Tutorials:
     - tutorials/index.md

--- a/src/ml4t/data/providers/__init__.py
+++ b/src/ml4t/data/providers/__init__.py
@@ -2,7 +2,7 @@
 
 This module provides unified access to multiple financial data providers.
 
-Available Providers:
+Available Providers (20 live + 3 synthetic/testing):
     - BaseProvider: Abstract base class for all providers
     - YahooFinanceProvider: Yahoo Finance (free, no API key)
     - TiingoProvider: Tiingo stocks (free tier: 1000 req/day, 500 symbols/month)
@@ -12,17 +12,20 @@ Available Providers:
     - AQRFactorProvider: AQR research factors (QMJ, BAB, VME)
     - FamaFrenchProvider: Fama-French factors (3-factor, 5-factor, momentum)
     - KalshiProvider: Kalshi prediction markets (no API key needed for public data)
+    - PolymarketProvider: Polymarket prediction market history/order book snapshots
     - CoinGeckoProvider: CoinGecko crypto data (free, no API key)
-    - TwelveDataProvider: Twelve Data multi-asset (stocks, forex, crypto)
-    - PolygonProvider: Polygon multi-asset (stocks, options, crypto, forex)
     - BinanceProvider: Binance cryptocurrency exchange (live API, may have geo-restrictions)
     - BinancePublicProvider: Binance public data (bulk downloads, no geo-restrictions)
-    - OandaProvider: Oanda forex and CFDs
+    - OKXProvider: OKX crypto perpetuals and funding rates (no geo-restrictions)
     - CryptoCompareProvider: CryptoCompare crypto data
+    - TwelveDataProvider: Twelve Data multi-asset (stocks, forex, crypto)
+    - PolygonProvider: Polygon multi-asset (stocks, options, crypto, forex)
+    - OandaProvider: Oanda forex and CFDs
     - DataBentoProvider: DataBento market data
     - ITCHSampleProvider: NASDAQ TotalView-ITCH sample data (tick-level, free)
     - WikiPricesProvider: Quandl Wiki Prices (US equities 1962-2018, free)
     - SyntheticProvider: Synthetic data generator (no network required)
+    - LearnedSyntheticProvider: ML-based synthetic data generator (no network required)
     - MockProvider: Mock provider for testing
 
 Note: Updater classes have been removed to simplify the library.


### PR DESCRIPTION
## Summary
- Fix 7 broken absolute paths in docs (replaced `/home/stefan/ml4t/software/` refs)
- Delete duplicate stub docs (`fama-french.md`, `wiki-prices.md`), fix index links
- Reconcile provider counts: **20 live providers** documented consistently across README, mkdocs nav, provider index, and FEATURE_INVENTORY
- Fill 4 stub pages with real content: CLI reference (228 lines), configuration (258 lines), data quality (231 lines), storage (240 lines)
- Expand API reference from 24 to 421 lines with mkdocstrings entries for all key classes
- Create root `CONTRIBUTING.md` (133 lines) consolidating from `docs/contributing/`
- Add new OKX provider documentation page

Net: +1,693 lines of documentation.

## Test plan
- [x] ruff check + format pass
- [x] No source code changes affect tests (only docs + providers/__init__.py docstring)
- [x] All mkdocstrings paths verified against source files