### PR TITLE
fix: macro downloader thread safety and Polars join API

### DIFF
--- a/src/ml4t/data/macro/downloader.py
+++ b/src/ml4t/data/macro/downloader.py
@@ -251,6 +251,7 @@ class MacroDataManager:
                     end=self.config.end,
                     progress=False,
                     auto_adjust=True,
+                    threads=False,
                 )
 
                 if df.empty:
@@ -281,7 +282,7 @@ class MacroDataManager:
         # Join all series on timestamp
         result = dfs[0]
         for df in dfs[1:]:
-            result = result.join(df, on="timestamp", how="outer_coalesce")
+            result = result.join(df, on="timestamp", how="full", coalesce=True)
 
         return result.sort("timestamp")
 


### PR DESCRIPTION
Cherry-pick from PR #6 (which was marked merged but didn't land on main):
- Add threads=False to yfinance download for thread safety
- Fix Polars join API: outer_coalesce → full + coalesce=True