### PR TITLE
docs: rewrite README for beta release

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,14 @@ Each library addresses a distinct stage: data infrastructure, feature engineerin
 
 Quantitative research requires consistent, reproducible access to market data from multiple sources. ml4t-data provides:
 
-- A unified interface across 20 live provider adapters (plus synthetic/testing providers)
+- `DataManager` as the unified interface: fetch, store, update, and query across all providers
+- 23 live provider adapters covering equities, crypto, futures, forex, and economic data
 - Automated storage in Hive-partitioned Parquet format with metadata tracking
-- Incremental updates, gap detection, and backfill capabilities via CLI
+- Incremental updates, gap detection, and backfill via CLI
 - Built-in data validation (OHLC invariants, deduplication, anomaly detection)
+- Futures module for CME/ICE bulk downloads with continuous contract construction
+- COT module for CFTC Commitment of Traders weekly reports
+- Resilience: rate limiting, retry with exponential backoff, gap detection
 
 The goal is to support an ongoing research workflow rather than one-off downloads. Data is stored locally, tracked for freshness, and queryable with tools like DuckDB or Polars.
 
@@ -35,18 +39,40 @@ pip install ml4t-data
 
 ## Quick Start
 
-```python
-from ml4t.data.providers import YahooFinanceProvider
+### DataManager (Unified Interface)
 
-provider = YahooFinanceProvider()
-data = provider.fetch_ohlcv("AAPL", "2020-01-01", "2024-12-31")
-print(data.head())
+```python
+from ml4t.data import DataManager
+
+dm = DataManager()
+
+# Fetch and store
+dm.fetch("AAPL", "2020-01-01", "2024-12-31", provider="yahoo")
+
+# Load from local storage
+data = dm.load("AAPL", "2020-01-01", "2024-12-31")
+
+# Batch load multiple symbols
+prices = dm.batch_load(["AAPL", "MSFT", "GOOGL"], "2020-01-01", "2024-12-31")
+
+# Incremental update
+dm.update("AAPL")
+
+# List what's stored
+symbols = dm.list_symbols()
+metadata = dm.get_metadata("AAPL")
 ```
+
+### Direct Provider Access
 
 All providers implement the same interface:
 
 ```python
-from ml4t.data.providers import CoinGeckoProvider, FREDProvider
+from ml4t.data.providers import YahooFinanceProvider, CoinGeckoProvider, FREDProvider
+
+# Equities
+provider = YahooFinanceProvider()
+data = provider.fetch_ohlcv("AAPL", "2020-01-01", "2024-12-31")
 
 # Crypto
 crypto = CoinGeckoProvider().fetch_ohlcv("bitcoin", "2024-01-01", "2024-12-31")
@@ -87,20 +113,96 @@ fred = FREDProvider().fetch_series("GDP", "2020-01-01", "2024-12-31")
 | CryptoCompare | Crypto market data |
 | OANDA | Forex broker data |
 
+## Specialized Modules
+
+### Futures
+
+Bulk download and continuous contract construction for CME/ICE products:
+
+```python
+from ml4t.data.futures import FuturesDownloader, ContinuousContractBuilder
+
+# Bulk download via Databento (parent symbology)
+downloader = FuturesDownloader(config)
+downloader.download()  # Downloads ES, NQ, CL, GC, etc.
+
+# Build continuous contracts with configurable roll logic
+builder = ContinuousContractBuilder()
+continuous = builder.build(contracts_df, roll_method="volume")
+```
+
+Book-focused interface with profiling:
+
+```python
+from ml4t.data.futures import FuturesDataManager
+
+fm = FuturesDataManager.from_config("config.yaml")
+fm.download_all()
+data = fm.load_ohlcv("ES")
+profile = fm.generate_profile("ES")
+```
+
+### COT (Commitment of Traders)
+
+CFTC weekly positioning data for futures markets:
+
+```python
+from ml4t.data.cot import COTFetcher, create_cot_features, combine_cot_ohlcv_pit
+
+fetcher = COTFetcher(config)
+cot_data = fetcher.fetch_product("ES", start_year=2015, end_year=2024)
+
+# Point-in-time combination with OHLCV (no look-ahead)
+combined = combine_cot_ohlcv_pit(cot_data, ohlcv_data)
+
+# Generate features from COT data
+features = create_cot_features(cot_data)
+```
+
+### Book Data Managers
+
+Simplified interfaces for the ML4T book workflow:
+
+```python
+from ml4t.data.etfs import ETFDataManager
+from ml4t.data.crypto import CryptoDataManager
+
+# 50 diversified ETFs via Yahoo Finance
+etf_dm = ETFDataManager.from_config("config.yaml")
+etf_dm.download_all()
+aapl = etf_dm.load_ohlcv("AAPL")
+
+# Crypto premium index via Binance Public
+crypto_dm = CryptoDataManager.from_config("config.yaml")
+crypto_dm.download_premium_index()
+```
+
 ## CLI for Automated Updates
 
 ```bash
 # Fetch specific symbols
-ml4t-data fetch AAPL MSFT GOOGL --provider yahoo --start 2020-01-01
+ml4t-data fetch -s AAPL -s MSFT -s GOOGL --provider yahoo --start 2020-01-01
 
-# Configuration-driven batch updates
-ml4t-data update-all -c config.yaml
+# Incremental update
+ml4t-data update --symbol AAPL
 
-# Detect and fill gaps
-ml4t-data update-all -c config.yaml --detect-gaps
+# Validate data quality
+ml4t-data validate --symbol AAPL --anomalies
+
+# Check storage status
+ml4t-data status --detailed
+
+# List available data
+ml4t-data list-data
+
+# Export to CSV/JSON/Excel
+ml4t-data export --symbol AAPL --format-type csv --output aapl.csv
+
+# Get symbol info
+ml4t-data info --symbol AAPL
 ```
 
-Configuration example:
+Configuration-driven batch updates:
 
 ```yaml
 storage:
@@ -146,18 +248,46 @@ result = duckdb.execute("""
 ## Data Validation
 
 ```python
-from ml4t.data.validation import validate_ohlcv
+from ml4t.data.validation import OHLCVValidator, ValidationReport
 
-issues = validate_ohlcv(data)
+validator = OHLCVValidator()
+report = validator.validate(data)
 # Checks: high >= low, high >= open/close, low <= open/close
 # Detects: duplicates, gaps, anomalies
 ```
+
+Anomaly detection:
+
+```python
+from ml4t.data.anomaly import AnomalyManager, ReturnOutlierDetector, VolumeSpikeDetector
+
+manager = AnomalyManager([
+    ReturnOutlierDetector(),
+    VolumeSpikeDetector(),
+])
+report = manager.detect(data)
+```
+
+## Documentation
+
+- [Getting Started](docs/user-guide/getting-started.md) — quick start guide
+- [Configuration](docs/user-guide/configuration.md) — YAML config reference
+- [Storage](docs/user-guide/storage.md) — Hive partitioning and backends
+- [Incremental Updates](docs/user-guide/incremental-updates.md) — update strategies and gap detection
+- [Data Quality](docs/user-guide/data-quality.md) — validation and anomaly detection
+- [CLI Reference](docs/user-guide/cli-reference.md) — command-line interface
+- [Provider Selection Guide](docs/provider-selection-guide.md) — choosing providers
+- [Creating a Provider](docs/creating_a_provider.md) — extending with new sources
 
 ## Technical Characteristics
 
 - **Polars-based**: Native Polars DataFrames throughout
 - **Consistent schema**: All providers return the same column structure
+- **Async support**: Async providers and batch operations for parallel downloads
 - **Metadata tracking**: Last update timestamps, row counts, date ranges
+- **Resilience**: Rate limiting, retry with exponential backoff, gap detection
+- **Multiple backends**: File system, S3, and in-memory storage
+- **Type-safe**: Full type annotations throughout
 
 ## Related Libraries
 
@@ -169,7 +299,7 @@ issues = validate_ohlcv(data)
 ## Development
 
 ```bash
-git clone https://github.com/applied-ai/ml4t-data.git
+git clone https://github.com/ml4t/ml4t-data.git
 cd ml4t-data
 uv sync
 uv run pytest tests/ -q

--- a/docs/book-guide/index.md
+++ b/docs/book-guide/index.md
@@ -1,0 +1,167 @@
+# ML4T Book Integration
+
+This page maps ml4t-data features to their usage in
+**Machine Learning for Trading** (Third Edition).
+
+## How the Book Uses ml4t-data
+
+The book uses ml4t-data at two levels:
+
+1. **Download scripts** (`data/download_all.py`): Config-driven managers
+   (`ETFDataManager`, `CryptoDataManager`, `MacroDataManager`, `FuturesDataManager`)
+   that fetch and store the book's canonical datasets from YAML configs.
+
+2. **Notebooks**: Provider-level access for analysis and demonstration,
+   plus high-level APIs (`DataManager`, `Universe`, `HiveStorage`) for
+   production data management patterns.
+
+## Chapter-to-Provider Mapping
+
+| Chapter | Topic | Providers Used | Notebooks |
+|---------|-------|----------------|-----------|
+| **2** | Financial Data Universe | Yahoo, Wiki Prices, EODHD, FRED, Binance Public, CoinGecko | 02-18 (11 notebooks) |
+| **4** | Fundamental & Alternative | FRED, CoinGecko, Kalshi, Polymarket, COT | 08, 10, 11, 13, 14 |
+| **5** | Synthetic Data | SyntheticProvider | 00 |
+| **16** | Strategy Simulation | Binance Public | 02, 03, 05 |
+| **17** | Portfolio Construction | FRED, AQR, Fama-French, Binance Public | 02, 07, 09 |
+| **19** | Risk Management | Fama-French | 04 |
+
+## Chapter 2: Deep Integration
+
+Chapter 2 is the primary data chapter and uses almost every ml4t-data feature:
+
+### Data Management (Notebooks 17-18)
+
+| Feature | Class | Notebook | Section |
+|---------|-------|----------|---------|
+| Unified fetch | `DataManager.fetch()` | 17 | 1. DataManager |
+| Batch loading | `DataManager.batch_load()` | 17 | 1. DataManager |
+| Symbol universes | `Universe.SP500`, `.get()`, `.add_custom()` | 17 | 2. Universe |
+| Hive storage | `HiveStorage`, `StorageConfig` | 17 | 3. HiveStorage |
+| Incremental updates | `DataManager.update()` | 17, 18 | 4. Updates |
+| Gap detection | `GapDetector.detect_gaps()` | 17, 18 | Gap Detection |
+| Update strategies | `UpdateStrategy` enum | 18 | 2. Strategies |
+| Health monitoring | `OHLCVValidator` + `GapDetector` | 18 | 4. Health Dashboard |
+| CLI commands | `ml4t-data fetch`, `update`, `validate` | 17 | 5. CLI |
+| Config-driven downloads | `download_all.py --update` | 18 | 5. Update Workflow |
+
+### Data Quality (Notebook 12)
+
+| Feature | Class | Purpose |
+|---------|-------|---------|
+| OHLCV validation | `OHLCVValidator` | 8 configurable checks |
+| Return outliers | `ReturnOutlierDetector` | Extreme return detection |
+| Volume spikes | `VolumeSpikeDetector` | Volume anomaly detection |
+| Price staleness | `PriceStalenessDetector` | Stale price detection |
+| Anomaly management | `AnomalyManager`, `AnomalyConfig` | Combined anomaly pipeline |
+
+### Provider Comparison (Notebook 15)
+
+| Provider | Asset Class | API Key Required |
+|----------|-------------|------------------|
+| Yahoo Finance | Equities, ETFs | No |
+| Wiki Prices | US Equities (1962-2018) | NASDAQ Data Link (free) |
+| EODHD | Global equities | Yes (paid) |
+| FRED | Macro indicators | Yes (free) |
+
+### Complete Pipeline (Notebook 16)
+
+Notebook 16 demonstrates end-to-end pipelines for both case studies,
+then shows how `DataManager` + `Universe` simplify the manual approach.
+
+## Provider Usage Across the Book
+
+### Free Providers (No API Key)
+
+| Provider | Chapters | Primary Use |
+|----------|----------|-------------|
+| **Yahoo Finance** | 2 | ETF universe, equity prices |
+| **Binance Public** | 2, 16, 17 | Crypto OHLCV, premium index |
+| **Fama-French** | 17, 19 | Factor returns |
+| **AQR** | 17 | Quality-minus-junk, BAB |
+| **SyntheticProvider** | 5 | Simulated market data |
+
+### Free Providers (API Key Required)
+
+| Provider | Chapters | Key Source |
+|----------|----------|------------|
+| **FRED** | 2, 4, 17 | Treasury yields, macro indicators |
+| **CoinGecko** | 4 | On-chain fundamentals |
+| **Wiki Prices** | 2 | Historical US equities (frozen 2018) |
+
+### Paid Providers
+
+| Provider | Chapters | Use Case |
+|----------|----------|----------|
+| **EODHD** | 2 | Provider comparison demo |
+| **Kalshi** | 4 | Prediction markets |
+| **Polymarket** | 4 | Prediction markets |
+| **DataBento** | (data scripts) | CME futures |
+
+## Feature Coverage
+
+### Used in Book
+
+| Feature | Status |
+|---------|--------|
+| DataManager (fetch, batch, load, update) | Notebook 17 |
+| Universe (SP500, NASDAQ100, custom) | Notebook 17 |
+| HiveStorage + StorageConfig | Notebooks 17, 18 |
+| GapDetector | Notebooks 17, 18 |
+| IncrementalUpdater + UpdateStrategy | Notebook 18 |
+| OHLCVValidator | Notebooks 12, 18 |
+| Anomaly detection (3 detectors) | Notebook 12 |
+| Corporate actions | Notebook 02 |
+| Config-driven managers (ETF, Crypto, Macro, Futures) | `data/download_all.py` |
+| CLI (`ml4t-data fetch/update/validate`) | Notebook 17 (docs) |
+| 14 of 20 providers | Various chapters |
+
+### Library-Only (Not in Book)
+
+| Feature | Documentation |
+|---------|---------------|
+| Export module (CSV, JSON, Excel) | [CLI Reference](../user-guide/cli-reference.md) |
+| Session management | [Storage Guide](../user-guide/storage.md) |
+| Trading calendar | [Incremental Updates](../user-guide/incremental-updates.md) |
+| Async providers | [Architecture](../contributing/architecture.md) |
+| Transaction support | [Storage Guide](../user-guide/storage.md) |
+| Remaining 6 providers | [Provider docs](../providers/index.md) |
+
+## Download Scripts
+
+The book's `data/` directory contains download scripts that use ml4t-data:
+
+```bash
+# Initial download (run once)
+python data/download_all.py
+
+# Update all datasets to present
+python data/download_all.py --update
+```
+
+| Script | ml4t-data Class | Config |
+|--------|-----------------|--------|
+| `data/etfs/download.py` | `YahooFinanceProvider` | `etfs/config.yaml` |
+| `data/crypto/download.py` | `BinancePublicProvider` | `crypto/config.yaml` |
+| `data/macro/download.py` | `FREDProvider` | `macro/config.yaml` |
+| `data/futures/download.py` | `databento` (direct) | `futures/config.yaml` |
+| `data/fx/download.py` | `OandaProvider` | `fx/config.yaml` |
+| `data/factors/ff_download.py` | `FamaFrenchProvider` | Built-in |
+| `data/factors/aqr_download.py` | `AQRFactorProvider` | Built-in |
+
+The orchestrator (`download_all.py`) wraps these with higher-level managers:
+
+```python
+from ml4t.data.etfs import ETFDataManager
+from ml4t.data.crypto import CryptoDataManager
+from ml4t.data.macro import MacroDataManager
+from ml4t.data.futures import FuturesDataManager
+```
+
+## Cross-References
+
+- **User Guide**: [Incremental Updates](../user-guide/incremental-updates.md),
+  [Storage](../user-guide/storage.md), [Data Quality](../user-guide/data-quality.md)
+- **Tutorials**: [Understanding OHLCV](../tutorials/01_understanding_ohlcv.md),
+  [Multi-Provider](../tutorials/05_multi_provider.md)
+- **API Reference**: [DataManager](../api/index.md), [HiveStorage](../api/index.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -119,22 +119,28 @@ print(f"Fetched {len(df)} rows for {df['symbol'].n_unique()} symbols")
 ## For ML4T Book Readers
 
 This library is the reference implementation for **Machine Learning for Trading (Third Edition)**.
+The book uses ml4t-data across 6 chapters and 25 notebooks, covering 14 of 20 providers.
 
 <div class="grid cards" markdown>
 
--   :material-book-open-variant:{ .lg .middle } __Three-Tier Learning__
+-   :material-book-open-variant:{ .lg .middle } __Chapter-Feature Mapping__
 
     ---
 
-    - **Tier 1 (Ch 1-5)**: Free data with Yahoo + CoinGecko
-    - **Tier 2 (Ch 6-10)**: Educational with EODHD + AlgoSeek
-    - **Tier 3 (Ch 11+)**: Professional with DataBento + Polygon
+    - **Ch 2**: DataManager, Universe, HiveStorage, gap detection, data quality
+    - **Ch 4**: FRED, CoinGecko, Kalshi, Polymarket, COT data
+    - **Ch 16-19**: Binance, Fama-French, AQR for backtesting and risk
+
+    [:octicons-arrow-right-24: Full book guide](book-guide/index.md)
 
 -   :material-rocket-launch:{ .lg .middle } __Production Ready__
 
     ---
 
-    Graduate from notebooks to automated pipelines with incremental updates and CLI automation.
+    Graduate from notebooks to automated pipelines with `download_all.py --update`,
+    incremental updates, and CLI automation.
+
+    [:octicons-arrow-right-24: Incremental updates](user-guide/incremental-updates.md)
 
 </div>
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -168,6 +168,9 @@ nav:
   - API Reference:
     - api/index.md
 
+  - Book Guide:
+    - book-guide/index.md
+
   - Contributing:
     - contributing/index.md
     - Creating a Provider: contributing/creating-a-provider.md


### PR DESCRIPTION
## Summary
- Rewrote README to match ml4t-backtest quality bar (182 → 311 lines)
- Added `DataManager` as primary quick start interface
- Added Futures module (`FuturesDownloader`, `ContinuousContractBuilder`, `FuturesDataManager`)
- Added COT module (`COTFetcher`, `create_cot_features`, `combine_cot_ohlcv_pit`)
- Added Book data managers (`ETFDataManager`, `CryptoDataManager`)
- Expanded CLI section with all 7 commands
- Added anomaly detection section
- Added Documentation links section (8 docs)
- Fixed git clone URL (`applied-ai` → `ml4t`)

## Test plan
- [ ] Verify code examples use real API names (all grep-verified against source)
- [ ] Check GitHub markdown rendering