### PR TITLE
ci: update test matrix to Python 3.12-3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 env:
-  PYTHON_VERSION: "3.11"
+  PYTHON_VERSION: "3.12"
 
 jobs:
   lint:
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- change the default CI Python version from 3.11 to 3.12
- update the core test matrix to run on Python 3.12, 3.13, and 3.14
- leave unrelated workflow files untouched

## Validation
- parsed .github/workflows/ci.yml with PyYAML to confirm the updated version values
