### PR TITLE
ci: standardize docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,13 +16,15 @@ jobs:
   build:
     name: Build & Deploy Docs
     runs-on: ubuntu-latest
+    env:
+      DOCS_DEPLOY_KEY: ${{ secrets.DOCS_DEPLOY_KEY }}
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "latest"
 
@@ -33,16 +35,13 @@ jobs:
         run: uv sync --dev --extra docs
 
       - name: Build docs
-        # The docs tree includes archived/reference pages and legacy relative
-        # links that are useful to keep but currently emit MkDocs warnings.
-        # Build failures should still stop deployment; warning cleanup can be
-        # handled separately without blocking docs publication.
         run: uv run mkdocs build
 
       - name: Deploy to website repo
+        if: ${{ env.DOCS_DEPLOY_KEY != '' }}
         uses: cpina/github-action-push-to-another-repository@v1.7.2
         env:
-          SSH_DEPLOY_KEY: ${{ secrets.DOCS_DEPLOY_KEY }}
+          SSH_DEPLOY_KEY: ${{ env.DOCS_DEPLOY_KEY }}
         with:
           source-directory: site/
           destination-github-username: ml4t


### PR DESCRIPTION
## Summary
- standardize the library docs deployment workflow on the shared website handoff pattern
- pin astral-sh/setup-uv to the official v8.1.0 commit from Astral's setup-uv documentation
- build docs with uv run mkdocs build and deploy site/ to website/static/docs/data/ when the deploy key is present

## Notes
- preserves the existing website-side docs rendering and navbar injection contract
- keeps the deploy target and URL structure unchanged
