### PR TITLE
test: make storage-path assertions symlink-safe on macOS

### DIFF
--- a/tests/futures/test_downloader.py
+++ b/tests/futures/test_downloader.py
@@ -634,7 +634,7 @@ futures:
         products, storage_path, defn_config = load_definitions_config(config_file)
 
         assert products == ["ES", "CL"]
-        assert storage_path == Path("/tmp/test")
+        assert storage_path == Path("/tmp/test").resolve()
         assert defn_config.strategy == "yearly_snapshots"
         assert defn_config.snapshot_dates == ["2024-01-02"]
         assert defn_config.output_file == "defs.parquet"

--- a/tests/test_cot.py
+++ b/tests/test_cot.py
@@ -173,7 +173,7 @@ class TestCOTConfig:
         assert config.products == ["ES", "CL"]
         assert config.start_year == 2018
         assert config.end_year == 2023
-        assert config.storage_path == Path("/tmp/cot")
+        assert config.storage_path == Path("/tmp/cot").resolve()
         assert config.include_options is True
 
     def test_get_years(self):
@@ -211,7 +211,7 @@ include_options: true
         assert config.products == ["ES", "CL", "GC"]
         assert config.start_year == 2019
         assert config.end_year == 2024
-        assert config.storage_path == Path("/tmp/cot_data")
+        assert config.storage_path == Path("/tmp/cot_data").resolve()
         assert config.include_options is True
 
 

--- a/tests/test_crypto_downloader.py
+++ b/tests/test_crypto_downloader.py
@@ -123,7 +123,7 @@ class TestCryptoDataManager:
 
     def test_init(self, manager, temp_storage):
         """Test initialization."""
-        assert manager.config.storage_path == temp_storage
+        assert manager.config.storage_path == temp_storage.resolve()
         assert manager._provider is None
         assert temp_storage.exists()
 

--- a/tests/test_etf_downloader.py
+++ b/tests/test_etf_downloader.py
@@ -120,7 +120,7 @@ class TestETFDataManager:
 
     def test_init(self, manager, temp_storage):
         """Test initialization."""
-        assert manager.config.storage_path == temp_storage
+        assert manager.config.storage_path == temp_storage.resolve()
         assert manager._provider is None
         assert temp_storage.exists()
 

--- a/tests/test_fama_french_provider.py
+++ b/tests/test_fama_french_provider.py
@@ -32,7 +32,7 @@ class TestFamaFrenchProviderInit:
             cache_path = Path(tmpdir) / "custom_cache"
             provider = FamaFrenchProvider(cache_path=cache_path)
 
-            assert provider.cache_path == cache_path
+            assert provider.cache_path == cache_path.resolve()
             assert cache_path.exists()
 
     def test_disable_cache(self):
@@ -132,10 +132,10 @@ class TestCaching:
             provider = FamaFrenchProvider(cache_path=tmpdir)
 
             path = provider._get_cache_path("ff3", "monthly")
-            assert path == Path(tmpdir) / "ff3_monthly.parquet"
+            assert path == Path(tmpdir).resolve() / "ff3_monthly.parquet"
 
             path = provider._get_cache_path("ff5", "daily")
-            assert path == Path(tmpdir) / "ff5_daily.parquet"
+            assert path == Path(tmpdir).resolve() / "ff5_daily.parquet"
 
     def test_clear_cache(self):
         """Test clear_cache removes cached files."""

--- a/tests/test_macro_downloader.py
+++ b/tests/test_macro_downloader.py
@@ -100,7 +100,7 @@ class TestMacroDataManager:
 
     def test_init(self, manager, temp_storage):
         """Test initialization."""
-        assert manager.config.storage_path == temp_storage
+        assert manager.config.storage_path == temp_storage.resolve()
         assert manager._provider is None
         assert temp_storage.exists()
 


### PR DESCRIPTION
## Problem

Several path-comparison assertions fail on **macOS** dev machines while passing on Linux CI. The production storage-path handling calls `.resolve()` (canonicalizing symlinks), so on macOS it returns `/private/tmp/...` / `/private/var/...` while the tests compare against the unresolved input (`/tmp/...`, `Path(tmpdir)`, the `temp_storage` fixture). On macOS `/tmp` and `/var` are symlinks to `/private/*`, so the assertions mismatch.

Example (`tests/test_fama_french_provider.py`):
```
assert PosixPath('/private/var/folders/.../ff3_monthly.parquet')
    == PosixPath('/var/folders/.../ff3_monthly.parquet')
```

These pass on `ubuntu-latest` (no `/tmp` symlink), so CI is green, but `uv run pytest` fails with 8 failures on macOS.

## Fix

Resolve the **expected** side of each assertion so it matches production's canonical path. This is a no-op on Linux and correct on macOS — no production code changes.

Assertions updated (9 across 6 files):
- `tests/futures/test_downloader.py`
- `tests/test_cot.py` (×2)
- `tests/test_crypto_downloader.py`
- `tests/test_etf_downloader.py`
- `tests/test_macro_downloader.py`
- `tests/test_fama_french_provider.py` (×3)

## Verification

- The 8 formerly-failing tests now pass on macOS.
- Full suite: **2,850 passed**, 0 failed (was 2,842 passed / 8 failed on macOS).
- `ruff check` + `ruff format --check` clean.
