### PR TITLE
Fix post-release hygiene issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ name = "ml4t-data"
 dynamic = ["version"]
 description = "High-performance market data management library with unified multi-provider interface"
 readme = "README.md"
-license = { text = "MIT" }
+license = "MIT"
+license-files = ["LICENSE"]
 authors = [
     { name = "ML4T Team", email = "info@ml4trading.io" },
 ]

--- a/scripts/verify_distribution.py
+++ b/scripts/verify_distribution.py
@@ -11,6 +11,7 @@ import sys
 import tarfile
 import tempfile
 import zipfile
+from email.message import Message
 from email.parser import Parser
 from pathlib import Path
 
@@ -18,7 +19,7 @@ PROJECT_NAME = "ml4t-data"
 TAG_PATTERN = re.compile(r"^v(?P<version>\d+\.\d+\.\d+(?:(?:a|b|rc)\d+)?)$")
 
 
-def _metadata_from_wheel(path: Path) -> tuple[str, str]:
+def _metadata_from_wheel(path: Path) -> Message:
     with zipfile.ZipFile(path) as archive:
         metadata_files = [
             name for name in archive.namelist() if name.endswith(".dist-info/METADATA")
@@ -26,11 +27,10 @@ def _metadata_from_wheel(path: Path) -> tuple[str, str]:
         if len(metadata_files) != 1:
             raise ValueError(f"{path.name} must contain exactly one METADATA file")
         content = archive.read(metadata_files[0]).decode("utf-8")
-    metadata = Parser().parsestr(content)
-    return metadata["Name"], metadata["Version"]
+    return Parser().parsestr(content)
 
 
-def _metadata_from_sdist(path: Path) -> tuple[str, str]:
+def _metadata_from_sdist(path: Path) -> Message:
     with tarfile.open(path, mode="r:gz") as archive:
         metadata_files = [
             member
@@ -43,8 +43,7 @@ def _metadata_from_sdist(path: Path) -> tuple[str, str]:
         if extracted is None:
             raise ValueError(f"could not read PKG-INFO from {path.name}")
         content = extracted.read().decode("utf-8")
-    metadata = Parser().parsestr(content)
-    return metadata["Name"], metadata["Version"]
+    return Parser().parsestr(content)
 
 
 def validate_distributions(
@@ -69,10 +68,21 @@ def validate_distributions(
 
     archives = [*wheels, *sdists]
     metadata = [_metadata_from_wheel(wheels[0]), _metadata_from_sdist(sdists[0])]
-    if any(name != PROJECT_NAME for name, _ in metadata):
-        raise ValueError(f"distribution name must be {PROJECT_NAME!r}: {metadata}")
+    names = [item["Name"] for item in metadata]
+    if any(name != PROJECT_NAME for name in names):
+        raise ValueError(f"distribution name must be {PROJECT_NAME!r}: {names}")
 
-    versions = {version for _, version in metadata}
+    for item in metadata:
+        license_expression = item["License-Expression"]
+        license_files = item.get_all("License-File", [])
+        if license_expression != "MIT" or "LICENSE" not in license_files:
+            raise ValueError(
+                "distribution license metadata must declare "
+                f"License-Expression: MIT and License-File: LICENSE: "
+                f"expression={license_expression!r}, files={license_files!r}"
+            )
+
+    versions = {item["Version"] for item in metadata}
     if len(versions) != 1:
         raise ValueError(f"wheel and sdist versions differ: {sorted(versions)}")
     version = versions.pop()
@@ -106,7 +116,7 @@ def verify_install(archive: Path, version: str) -> None:
         python = _venv_python(venv)
         subprocess.run(["uv", "pip", "install", "--python", str(python), str(archive)], check=True)
         subprocess.run(["uv", "pip", "check", "--python", str(python)], check=True)
-        subprocess.run(
+        completed = subprocess.run(
             [
                 str(python),
                 "-c",
@@ -116,7 +126,14 @@ def verify_install(archive: Path, version: str) -> None:
                 ),
             ],
             check=True,
+            capture_output=True,
+            text=True,
         )
+        if completed.stdout or completed.stderr:
+            raise ValueError(
+                f"{archive.name} import must be silent: "
+                f"stdout={completed.stdout!r}, stderr={completed.stderr!r}"
+            )
         subprocess.run([str(_venv_cli(venv)), "--help"], check=True, stdout=subprocess.DEVNULL)
 
 

--- a/src/ml4t/data/managers/provider_manager.py
+++ b/src/ml4t/data/managers/provider_manager.py
@@ -185,11 +185,7 @@ class ProviderManager:
             try:
                 provider_classes[spec.name] = spec.load_class()
             except ImportError:
-                logger.debug(
-                    "Provider dependency is not installed",
-                    provider=spec.name,
-                    extra=spec.extra,
-                )
+                continue
 
         cls._PROVIDER_CLASSES = provider_classes
         return provider_classes

--- a/src/ml4t/data/providers/kalshi.py
+++ b/src/ml4t/data/providers/kalshi.py
@@ -34,6 +34,7 @@ Example:
     >>> provider.close()
 """
 
+import time
 from datetime import datetime
 from typing import Any, ClassVar
 
@@ -75,6 +76,9 @@ class KalshiProvider(BaseProvider):
 
     # Kalshi API base URL (elections domain provides all markets)
     BASE_URL: ClassVar[str] = "https://api.elections.kalshi.com/trade-api/v2"
+
+    # Public requests can be rejected transiently by Kalshi's edge layer.
+    EDGE_403_RETRY_DELAY: ClassVar[float] = 1.0
 
     # Map common frequency names to Kalshi period_interval values
     FREQUENCY_MAP: ClassVar[dict[str, int]] = {
@@ -119,6 +123,20 @@ class KalshiProvider(BaseProvider):
         if self.api_key:
             headers["Authorization"] = f"Bearer {self.api_key}"
         return headers
+
+    def _is_unauthenticated_edge_forbidden(self, response: Any) -> bool:
+        """Identify an HTML 403 from the public API edge layer."""
+        if self.api_key or response.status_code != 403:
+            return False
+
+        headers = getattr(response, "headers", {})
+        content_type = str(headers.get("content-type", "")).lower()
+        body = str(getattr(response, "text", "")).lstrip().lower()
+        return (
+            "text/html" in content_type
+            or body.startswith("<!doctype html")
+            or body.startswith("<html")
+        )
 
     def _extract_series_ticker(self, market_ticker: str) -> str:
         """Extract series ticker from market ticker.
@@ -575,6 +593,19 @@ class KalshiProvider(BaseProvider):
                 params=params,
                 headers=self._get_headers(),
             )
+
+            if self._is_unauthenticated_edge_forbidden(response):
+                self.logger.warning(
+                    "Kalshi public endpoint returned an HTML 403; retrying once",
+                    endpoint=endpoint,
+                )
+                time.sleep(self.EDGE_403_RETRY_DELAY)
+                self._acquire_rate_limit()
+                response = self.session.get(
+                    endpoint,
+                    params=params,
+                    headers=self._get_headers(),
+                )
 
             if response.status_code != 200:
                 raise NetworkError(

--- a/tests/test_distribution_verification.py
+++ b/tests/test_distribution_verification.py
@@ -12,16 +12,28 @@ import pytest
 from scripts.verify_distribution import validate_distributions, write_checksums
 
 
-def _write_distributions(dist_dir: Path, version: str = "0.1.0") -> None:
+def _write_distributions(
+    dist_dir: Path,
+    version: str = "0.1.0",
+    license_expression: str | None = "MIT",
+    license_file: str | None = "LICENSE",
+) -> None:
+    metadata_fields = ["Metadata-Version: 2.4", "Name: ml4t-data", f"Version: {version}"]
+    if license_expression is not None:
+        metadata_fields.append(f"License-Expression: {license_expression}")
+    if license_file is not None:
+        metadata_fields.append(f"License-File: {license_file}")
+    metadata_text = "\n".join(metadata_fields) + "\n"
+
     wheel = dist_dir / f"ml4t_data-{version}-py3-none-any.whl"
     with zipfile.ZipFile(wheel, "w") as archive:
         archive.writestr(
             f"ml4t_data-{version}.dist-info/METADATA",
-            f"Metadata-Version: 2.4\nName: ml4t-data\nVersion: {version}\n",
+            metadata_text,
         )
 
     sdist = dist_dir / f"ml4t_data-{version}.tar.gz"
-    metadata = f"Metadata-Version: 2.4\nName: ml4t-data\nVersion: {version}\n".encode()
+    metadata = metadata_text.encode()
     member = tarfile.TarInfo(f"ml4t_data-{version}/PKG-INFO")
     member.size = len(metadata)
     with tarfile.open(sdist, "w:gz") as archive:
@@ -42,6 +54,23 @@ def test_distribution_metadata_rejects_tag_mismatch(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="does not match"):
         validate_distributions(tmp_path, "v0.1.1")
+
+
+@pytest.mark.parametrize(
+    ("license_expression", "license_file"),
+    [(None, "LICENSE"), ("Apache-2.0", "LICENSE"), ("MIT", None)],
+)
+def test_distribution_metadata_rejects_incorrect_license_metadata(
+    tmp_path: Path, license_expression: str | None, license_file: str | None
+) -> None:
+    _write_distributions(
+        tmp_path,
+        license_expression=license_expression,
+        license_file=license_file,
+    )
+
+    with pytest.raises(ValueError, match="license metadata"):
+        validate_distributions(tmp_path)
 
 
 @pytest.mark.parametrize("tag", ["0.1.0", "v0.1", "release-0.1.0", "v0.1.0.dev1"])

--- a/tests/test_kalshi_unit.py
+++ b/tests/test_kalshi_unit.py
@@ -23,6 +23,7 @@ import pytest
 from ml4t.data.core.exceptions import (
     DataNotAvailableError,
     DataValidationError,
+    NetworkError,
     SymbolNotFoundError,
 )
 from ml4t.data.providers.kalshi import KalshiProvider
@@ -540,6 +541,71 @@ class TestKalshiListMethods:
             call_kwargs = mock_get.call_args[1]
             params = call_kwargs["params"]
             assert params["series_ticker"] == "KXINFL"
+
+    def test_list_markets_retries_unauthenticated_html_403_once(self, provider):
+        """A transient edge-layer rejection is retried once for public data."""
+        forbidden = MagicMock()
+        forbidden.status_code = 403
+        forbidden.headers = {"content-type": "text/html; charset=utf-8"}
+        forbidden.text = "<!doctype html><title>Forbidden</title>"
+
+        success = MagicMock()
+        success.status_code = 200
+        success.json.return_value = {"markets": [{"ticker": "KXINFL-25JAN"}]}
+
+        with (
+            patch.object(provider.session, "get", side_effect=[forbidden, success]) as mock_get,
+            patch("ml4t.data.providers.kalshi.time.sleep") as mock_sleep,
+        ):
+            markets = provider.list_markets()
+
+        assert markets == [{"ticker": "KXINFL-25JAN"}]
+        assert mock_get.call_count == 2
+        mock_sleep.assert_called_once_with(provider.EDGE_403_RETRY_DELAY)
+
+    def test_list_markets_stops_after_one_html_403_retry(self, provider):
+        """A persistent edge rejection remains an explicit network failure."""
+        forbidden = MagicMock()
+        forbidden.status_code = 403
+        forbidden.headers = {"content-type": "text/html"}
+        forbidden.text = "<html><title>Forbidden</title></html>"
+
+        with (
+            patch.object(provider.session, "get", side_effect=[forbidden, forbidden]) as mock_get,
+            patch("ml4t.data.providers.kalshi.time.sleep") as mock_sleep,
+            pytest.raises(NetworkError, match="HTTP 403"),
+        ):
+            provider.list_markets()
+
+        assert mock_get.call_count == 2
+        mock_sleep.assert_called_once_with(provider.EDGE_403_RETRY_DELAY)
+
+    @pytest.mark.parametrize(
+        ("api_key", "content_type", "body"),
+        [
+            (None, "application/json", '{"error": "forbidden"}'),
+            ("test_api_key", "text/html", "<html><title>Forbidden</title></html>"),
+        ],
+    )
+    def test_list_markets_does_not_retry_authoritative_403(
+        self, provider, api_key, content_type, body
+    ):
+        """API and authenticated authorization failures are not retried."""
+        provider.api_key = api_key
+        forbidden = MagicMock()
+        forbidden.status_code = 403
+        forbidden.headers = {"content-type": content_type}
+        forbidden.text = body
+
+        with (
+            patch.object(provider.session, "get", return_value=forbidden) as mock_get,
+            patch("ml4t.data.providers.kalshi.time.sleep") as mock_sleep,
+            pytest.raises(NetworkError, match="HTTP 403"),
+        ):
+            provider.list_markets()
+
+        mock_get.assert_called_once()
+        mock_sleep.assert_not_called()
 
     def test_list_series_success(self, provider):
         """Test successful list_series with mocked response."""

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -42,6 +42,14 @@ def test_supported_python_and_platform_metadata() -> None:
     assert "Programming Language :: Python :: 3.15" not in classifiers
 
 
+def test_license_uses_spdx_metadata() -> None:
+    """Built distributions declare the MIT license using PEP 639 metadata."""
+    project = load_project()
+
+    assert project["license"] == "MIT"
+    assert project["license-files"] == ["LICENSE"]
+
+
 def test_source_distribution_contains_release_verifiers() -> None:
     """Tests shipped in the source archive can import their release helpers."""
     included = set(load_config()["tool"]["hatch"]["build"]["targets"]["sdist"]["include"])
@@ -96,3 +104,39 @@ def test_core_futures_import_does_not_require_databento_extra() -> None:
     )
 
     subprocess.run([sys.executable, "-c", script], cwd=PROJECT_ROOT, check=True)
+
+
+def test_core_import_is_silent_without_optional_provider_dependencies() -> None:
+    """Missing optional provider clients do not write during a core import."""
+    script = textwrap.dedent(
+        """
+        import builtins
+
+        original_import = builtins.__import__
+
+        def block_optional_clients(name, *args, **kwargs):
+            if (
+                name == "databento"
+                or name.startswith("databento.")
+                or name == "oandapyV20"
+                or name.startswith("oandapyV20.")
+            ):
+                raise ModuleNotFoundError("blocked optional dependency", name=name)
+            return original_import(name, *args, **kwargs)
+
+        builtins.__import__ = block_optional_clients
+
+        import ml4t.data
+        """
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=PROJECT_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.stdout == ""
+    assert completed.stderr == ""


### PR DESCRIPTION
Closes #32
Closes #34
Closes #35

- retry one transient unauthenticated Kalshi HTML 403
- keep core imports silent when optional provider clients are absent
- publish and validate SPDX MIT distribution metadata

Validation:
- 3,580 offline tests passed
- live Kalshi contract passed
- Ruff and ty passed
- strict documentation build passed
- wheel and sdist isolated install checks passed