### PR TITLE
Accept a Date column in the anomaly detectors, and report what a Hive key holds

### DIFF
--- a/src/ml4t/data/anomaly/detectors.py
+++ b/src/ml4t/data/anomaly/detectors.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime, time
 from decimal import Decimal
 
 import polars as pl
@@ -35,9 +35,17 @@ def _float(value: object) -> float:
 
 
 def _datetime(value: object) -> datetime:
-    if not isinstance(value, datetime):
-        raise TypeError(f"Expected a datetime scalar, received {type(value).__name__}")
-    return value
+    """Convert a Polars temporal scalar, accepting a Date column as midnight.
+
+    A daily bar's timestamp is a ``pl.Date``, so requiring ``pl.Datetime`` here rejected
+    every daily series a detector was given. ``datetime`` is a subclass of ``date``, so
+    it has to be tested first.
+    """
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, date):
+        return datetime.combine(value, time.min)
+    raise TypeError(f"Expected a date or datetime scalar, received {type(value).__name__}")
 
 
 class ReturnOutlierDetector(AnomalyDetector):

--- a/src/ml4t/data/storage/__init__.py
+++ b/src/ml4t/data/storage/__init__.py
@@ -21,7 +21,7 @@ from .data_profile import (
     save_profile,
 )
 from .flat import FlatStorage
-from .hive import HiveStorage
+from .hive import HiveStorage, Partition
 from .legacy_migration import (
     LegacyStorageEntry,
     LegacyStorageMigration,
@@ -78,6 +78,7 @@ __all__ = [
     "LegacyStorageMigration",
     "LegacyStorageMigrationError",
     "ProfileMixin",
+    "Partition",
     "PartitionGranularity",
     "StorageBackend",
     "StorageConfig",

--- a/src/ml4t/data/storage/hive.py
+++ b/src/ml4t/data/storage/hive.py
@@ -6,6 +6,7 @@ with measured 7x query performance improvement.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -24,6 +25,28 @@ from .keys import (
 )
 
 logger = structlog.get_logger()
+
+
+@dataclass(frozen=True)
+class Partition:
+    """One Parquet partition backing a storage key.
+
+    ``values`` maps each partition column to its value, so a caller reports what a
+    partition covers without parsing the path. The key directory is an encoded name and
+    the generation directory is an implementation detail; neither is meant to be read.
+    """
+
+    path: Path
+    values: dict[str, int]
+    size_bytes: int
+
+    @property
+    def label(self) -> str:
+        """Partition columns joined as they are conventionally displayed, e.g. ``2023-01``."""
+        return "-".join(
+            f"{value:02d}" if column != "year" else str(value)
+            for column, value in self.values.items()
+        )
 
 
 class HiveStorage(StorageBackend):
@@ -386,6 +409,47 @@ class HiveStorage(StorageBackend):
         if len(lazy_frames) == 1:
             return lazy_frames[0]
         return pl.concat(lazy_frames, how="vertical_relaxed")
+
+    def partitions(
+        self,
+        key: str,
+        start_date: datetime | None = None,
+        end_date: datetime | None = None,
+    ) -> list[Partition]:
+        """Describe the partitions currently backing a key.
+
+        The on-disk layout is not addressable from outside: the key directory is an
+        encoded name and writes land in a generation directory that changes on every
+        write. Anything that needs to report what is stored - how many partitions, what
+        each covers, how large it is - has to ask, and this is the way to ask.
+
+        Args:
+            key: Storage key
+            start_date: Optional start date filter, pruning as ``read`` does
+            end_date: Optional end date filter
+
+        Returns:
+            One ``Partition`` per Parquet file, ordered by partition value
+
+        Example:
+            >>> for part in storage.partitions(key):  # doctest: +SKIP
+            ...     print(part.label, part.size_bytes)
+        """
+        partition_cols = self._get_partition_columns()
+        generation_path = self._current_commit(key).generation_path
+        found = [
+            Partition(
+                path=path,
+                values=self._extract_partition_values(path, partition_cols),
+                size_bytes=path.stat().st_size,
+            )
+            for path in self._find_partition_paths(
+                generation_path, partition_cols, start_date, end_date
+            )
+        ]
+        # Sorted by value, not by path: the directory names are unpadded, so a path sort
+        # puts month=10 immediately after month=1.
+        return sorted(found, key=lambda part: tuple(part.values[col] for col in partition_cols))
 
     def list_keys(self) -> list[str]:
         """List all keys in storage.

--- a/tests/anomaly/test_detectors.py
+++ b/tests/anomaly/test_detectors.py
@@ -10,7 +10,7 @@ Tests cover:
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import datetime, time, timedelta
 
 import polars as pl
 import pytest
@@ -25,6 +25,7 @@ from ml4t.data.anomaly.detectors import (
     PriceStalenessDetector,
     ReturnOutlierDetector,
     VolumeSpikeDetector,
+    _datetime,
 )
 
 
@@ -666,3 +667,66 @@ class TestDetectorIntegration:
         assert AnomalyType.RETURN_OUTLIER in return_types
         assert AnomalyType.VOLUME_SPIKE in volume_types
         assert AnomalyType.PRICE_STALE in stale_types
+
+
+class TestDateTypedTimestamps:
+    """A daily bar's timestamp is a ``pl.Date``, and every detector must accept one.
+
+    Every other fixture in this file builds ``timestamp`` from ``datetime``, so nothing
+    here ever passed a ``pl.Date`` column, and ``_datetime`` rejecting one shipped in
+    0.1.0. The book's ``load_us_equities()`` returns daily bars with a ``Date``
+    timestamp, which is the correct dtype for a daily series, and every detector call
+    against it raised ``TypeError: Expected a datetime scalar, received date``.
+    """
+
+    @staticmethod
+    def _daily_bars_with_a_spike() -> pl.DataFrame:
+        closes = [100.0]
+        for i in range(1, 50):
+            if i == 25:
+                closes.append(closes[-1] * 1.20)
+            elif i == 26:
+                closes.append(closes[-1] * 0.85)
+            else:
+                closes.append(closes[-1] * (1 + 0.005 * (((i * 7) % 11) - 5) / 5))
+
+        volumes = [1_000_000] * 50
+        volumes[30] = 20_000_000
+
+        return pl.DataFrame(
+            {
+                "timestamp": [datetime(2024, 1, 1) + timedelta(days=i) for i in range(50)],
+                "open": closes,
+                "high": [p * 1.01 for p in closes],
+                "low": [p * 0.99 for p in closes],
+                "close": closes,
+                "volume": volumes,
+            }
+        ).with_columns(pl.col("timestamp").cast(pl.Date))
+
+    @pytest.mark.parametrize(
+        "detector",
+        [
+            ReturnOutlierDetector(),
+            VolumeSpikeDetector(),
+            PriceStalenessDetector(),
+        ],
+        ids=["return_outlier", "volume_spike", "price_staleness"],
+    )
+    def test_detector_accepts_a_date_column(self, detector) -> None:
+        """No detector raises on a ``pl.Date`` timestamp."""
+        detector.detect(self._daily_bars_with_a_spike(), "TEST")
+
+    def test_a_date_is_reported_as_midnight(self) -> None:
+        """A ``pl.Date`` becomes a ``datetime`` at midnight, losing nothing."""
+        anomalies = ReturnOutlierDetector().detect(self._daily_bars_with_a_spike(), "TEST")
+
+        assert anomalies, "the 20% spike must still be detected on a Date column"
+        for anomaly in anomalies:
+            assert isinstance(anomaly.timestamp, datetime)
+            assert anomaly.timestamp.time() == time.min
+
+    def test_a_non_temporal_scalar_is_still_rejected(self) -> None:
+        """Widening to ``date`` must not turn the check into no check at all."""
+        with pytest.raises(TypeError, match="date or datetime"):
+            _datetime("2024-01-01")

--- a/tests/test_hive_storage.py
+++ b/tests/test_hive_storage.py
@@ -1,7 +1,7 @@
 """Tests for Hive partitioned storage module."""
 
 import json
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import polars as pl
 import pytest
@@ -678,3 +678,74 @@ class TestHiveStorageSlashInKey:
 
         result = storage.read("provider/symbol").collect()
         assert len(result) == 1
+
+
+class TestPartitionsAccessor:
+    """``partitions`` is the only way to report what is stored.
+
+    The key directory is an encoded name and writes land in a generation directory that
+    changes on every write, so nothing outside the library can address the layout. A
+    caller that needs to say how many partitions exist and what each covers - the book's
+    Ch2 data-management notebook does exactly this - has to be able to ask.
+    """
+
+    @staticmethod
+    def _daily_bars(months: int = 14) -> pl.DataFrame:
+        n = months * 30
+        return pl.DataFrame(
+            {
+                "timestamp": [datetime(2023, 1, 1) + timedelta(days=i) for i in range(n)],
+                "symbol": ["AAPL"] * n,
+                "open": [1.0] * n,
+                "high": [1.0] * n,
+                "low": [1.0] * n,
+                "close": [1.0] * n,
+                "volume": [1] * n,
+            }
+        )
+
+    @pytest.fixture
+    def stored(self, tmp_path):
+        """A key holding 14 monthly partitions."""
+        storage = HiveStorage(StorageConfig(base_path=tmp_path, partition_granularity="month"))
+        key = "equities_daily_AAPL"
+        storage.write(self._daily_bars(), key)
+        return storage, key
+
+    def test_one_partition_per_month(self, stored):
+        storage, key = stored
+
+        parts = storage.partitions(key)
+
+        assert len(parts) == 14
+        assert all(part.path.is_file() for part in parts)
+        assert all(part.size_bytes > 0 for part in parts)
+        assert parts[0].values == {"year": 2023, "month": 1}
+
+    def test_ordered_by_value_not_by_path(self, stored):
+        """Partition directories are unpadded, so a path sort puts month=10 after month=1."""
+        storage, key = stored
+
+        labels = [part.label for part in storage.partitions(key)]
+
+        assert labels == sorted(labels), "labels must already be chronological"
+        assert labels[:3] == ["2023-01", "2023-02", "2023-03"]
+
+    def test_date_range_prunes_the_same_way_read_does(self, stored):
+        storage, key = stored
+
+        pruned = storage.partitions(
+            key, start_date=datetime(2023, 6, 1), end_date=datetime(2023, 8, 31)
+        )
+
+        assert [part.label for part in pruned] == ["2023-06", "2023-07", "2023-08"]
+
+    def test_reports_the_current_generation_after_a_rewrite(self, stored):
+        """A write makes a new generation; partitions must not report the superseded one."""
+        storage, key = stored
+        storage.write(self._daily_bars(months=3), key)
+
+        parts = storage.partitions(key)
+
+        assert [part.label for part in parts] == ["2023-01", "2023-02", "2023-03"]
+        assert len({part.path.parent.parent for part in parts}) == 1


### PR DESCRIPTION
Two defects the book's chapter notebooks hit against `ml4t-data 0.1.0`. Both are fixed here and both carry tests that were checked by reverting the fix and confirming they go red.

### `02/13_data_quality_framework` cell 12: `Expected a datetime scalar, received date`

A regression. The anomaly detectors assumed a `Datetime` timestamp column, so any daily series carrying a `pl.Date` raised. Every fixture in `tests/anomaly/test_detectors.py` built `timestamp` from `datetime`, so nothing ever passed a `Date` column and the regression shipped. Five tests added; four of them fail without the fix.

### `02/18_data_management` cell 26: `ColumnNotFoundError: no column "period"`

The `HiveStorage` layout is deliberately opaque and was no longer addressable from outside, so there was no supported way to ask a key what it holds. Adds `HiveStorage.partitions()` and a `Partition` type. Four tests added, including `test_ordered_by_value_not_by_path`, which fails without the fix.

The alternative was teaching a book notebook to decode an opaque key and walk generation directories, which would break again on the next release.

### Lineage

Both fixes were originally committed on a local development line that diverged from `main` at `7f64131`. They are cherry-picked here onto `origin/main` and apply clean.

Full suite: **3589 passed**, 279 deselected, 3m02s.