### PR TITLE
docs: point AGENTS.md at the book-guide chapter-to-API cross-reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ Market data acquisition and storage library for ML4T 3rd Edition.
 | `tests/`           | Test suite                       |
 | `examples/`        | Usage examples                   |
 | `docs/`            | MkDocs documentation             |
+| `docs/book-guide/index.md` | Chapter-to-API cross-reference: which book notebook uses which class/function |
 
 ## Key Modules
 


### PR DESCRIPTION
## Summary
- AGENTS.md had no pointer to the existing docs/book-guide/index.md chapter-notebook-to-API mapping, unlike ml4t-engineer and ml4t-diagnostic. Adds one row to the Structure table.

## Test plan
- Docs-only change; pre-commit hooks pass.