### PR TITLE
fix(etfs): rebuild combined file from partitions, not stale aggregate

### DIFF
--- a/src/ml4t/data/etfs/downloader.py
+++ b/src/ml4t/data/etfs/downloader.py
@@ -350,7 +350,7 @@ class ETFDataManager(ProfileMixin):
 
     def _regenerate_combined(self) -> None:
         """Regenerate combined file from individual ticker files."""
-        all_data = self.load_all()
+        all_data = self.load_symbols(self.config.get_all_symbols())
         if not all_data.is_empty():
             self._save_combined(all_data)
 

--- a/tests/test_regenerate_combined.py
+++ b/tests/test_regenerate_combined.py
@@ -1,0 +1,78 @@
+"""Regression tests for combined-file regeneration."""
+
+from datetime import datetime
+
+import polars as pl
+
+from ml4t.data.etfs.downloader import ETFConfig, ETFDataManager
+
+
+def _bars(symbol: str, timestamps: list[datetime]) -> pl.DataFrame:
+    """Minimal OHLCV frame for one symbol."""
+    n = len(timestamps)
+    return pl.DataFrame(
+        {
+            "timestamp": timestamps,
+            "symbol": [symbol] * n,
+            "open": [1.0] * n,
+            "high": [1.0] * n,
+            "low": [1.0] * n,
+            "close": [1.0] * n,
+            "volume": [100.0] * n,
+        },
+        schema_overrides={"timestamp": pl.Datetime},
+    )
+
+
+class TestRegenerateCombined:
+    """Tests for ETFDataManager._regenerate_combined."""
+
+    def test_rebuilds_from_partitions_when_aggregate_is_stale(self, tmp_path):
+        """A stale combined file must not survive regeneration.
+
+        ``update()`` writes fresh bars to the per-ticker partitions and then
+        calls ``_regenerate_combined()``. If regeneration reads the existing
+        aggregate instead of the partitions, the stale file is rewritten
+        unchanged and every downstream reader silently sees old data.
+        """
+        config = ETFConfig(
+            storage_path=tmp_path,
+            tickers={"equity": {"symbols": ["SPY"]}},
+        )
+        manager = ETFDataManager(config)
+
+        # Partition holds bars through the newer date.
+        fresh = _bars("SPY", [datetime(2025, 12, 31), datetime(2026, 8, 20)])
+        manager._save_ticker(fresh, "SPY")
+
+        # Aggregate is stale: it stops at the older date.
+        stale = _bars("SPY", [datetime(2025, 12, 31)])
+        manager._save_combined(stale)
+
+        manager._regenerate_combined()
+
+        combined = pl.read_parquet(tmp_path / "etf_universe.parquet")
+        assert combined["timestamp"].max() == datetime(2026, 8, 20), (
+            "combined file was not rebuilt from the ticker partitions"
+        )
+        assert combined.height == 2
+
+    def test_picks_up_a_symbol_absent_from_the_aggregate(self, tmp_path):
+        """A partition missing from the aggregate must appear after regeneration."""
+        config = ETFConfig(
+            storage_path=tmp_path,
+            tickers={"equity": {"symbols": ["SPY", "QQQ"]}},
+        )
+        manager = ETFDataManager(config)
+
+        ts = [datetime(2026, 8, 20)]
+        manager._save_ticker(_bars("SPY", ts), "SPY")
+        manager._save_ticker(_bars("QQQ", ts), "QQQ")
+
+        # Aggregate predates QQQ being added to the universe.
+        manager._save_combined(_bars("SPY", ts))
+
+        manager._regenerate_combined()
+
+        combined = pl.read_parquet(tmp_path / "etf_universe.parquet")
+        assert set(combined["symbol"].unique()) == {"SPY", "QQQ"}


### PR DESCRIPTION
Summary

Fixes ETFDataManager._regenerate_combined() so it actually rebuilds etf_universe.parquet from the individual ticker partitions.

Problem

_regenerate_combined() currently calls:

all_data = self.load_all()

but load_all() prefers the existing etf_universe.parquet when that file exists. This means _regenerate_combined() can read the stale combined file and write it straight back out, even after the individual ticker partitions have been updated successfully.

In practice, I reproduced this with the ML4T Chapter 25 ETF deployment loop:

individual ticker partitions advanced through 2026-08-20
ETFDataManager.update() reported new rows
_regenerate_combined() ran
the combined aggregate still ended at 2025-12-31

Deleting the combined file caused load_all() to fall back to load_symbols(...), after which the aggregate rebuilt correctly. That isolated the issue to the cache-preferring behavior of load_all().

Fix

Change _regenerate_combined() to load the configured ticker partitions directly:

all_data = self.load_symbols(self.config.get_all_symbols())

This matches the method docstring (“Regenerate combined file from individual ticker files”) and uses the same partition-loading path that load_all() already falls back to when the aggregate is absent.

Tests

Added regression coverage for:

rebuilding when an existing aggregate is stale
restoring symbols present in ticker partitions but missing from the aggregate

Targeted test run:

37 passed, 2 warnings
End-to-end verification

I installed this branch into the machine-learning-for-trading project via a SHA-pinned uv Git source and reran the Chapter 25 ETF deployment loop with the existing frozen etf_universe.parquet still present.

Before the fix, the combined file remained at:

470,662 rows, ending 2025-12-31

After the fix, the normal refresh path rebuilt it successfully without deleting the aggregate first:

ml4t-data update: 318 new rows across 2 symbols
Prices: 486,552 rows x 100 symbols, 2006-01-03 to 2026-08-20

No changes were made to the deployment logic itself; this PR only fixes aggregate regeneration inside ml4t-data.