### PR TITLE
Decouple live provider availability from package releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,25 +33,6 @@ jobs:
     permissions:
       contents: read
 
-  provider-contracts:
-    name: Verify Provider Contracts
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Require successful live contracts for this commit
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_COMMIT: ${{ github.sha }}
-        run: >-
-          python scripts/verify_provider_contract_runs.py
-          --repository "${{ github.repository }}" --commit "$RELEASE_COMMIT"
-
   quality:
     name: Release Quality and Security
     runs-on: ubuntu-latest
@@ -92,7 +73,7 @@ jobs:
   build:
     name: Build Validated Artifacts
     runs-on: ubuntu-latest
-    needs: [ecosystem-qualification, compatibility, provider-contracts, quality]
+    needs: [ecosystem-qualification, compatibility, quality]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -51,7 +51,6 @@ def test_publish_uses_only_the_validated_package_directory() -> None:
     assert build["needs"] == [
         "ecosystem-qualification",
         "compatibility",
-        "provider-contracts",
         "quality",
     ]
     assert publish["needs"] == "build"
@@ -146,18 +145,11 @@ def test_provider_contract_dispatch_selects_exactly_one_job() -> None:
     assert "allow-paid-requests" not in inputs
 
 
-def test_release_requires_provider_contracts_for_the_tagged_commit() -> None:
+def test_live_provider_availability_does_not_block_package_releases() -> None:
     jobs = _load("release.yml")["jobs"]
-    verification = jobs["provider-contracts"]
-    step = next(
-        step
-        for step in verification["steps"]
-        if step.get("name") == "Require successful live contracts for this commit"
-    )
 
-    assert verification["permissions"] == {"actions": "read", "contents": "read"}
-    assert step["env"]["RELEASE_COMMIT"] == "${{ github.sha }}"
-    assert "verify_provider_contract_runs.py" in step["run"]
+    assert "provider-contracts" not in jobs
+    assert "provider-contracts" not in jobs["build"]["needs"]
 
 
 def test_release_rechecks_quality_docs_and_dependencies() -> None:


### PR DESCRIPTION
Package publication currently requires successful live calls to every credentialed provider for the exact release commit. A transient Alpaca HTTP 504 therefore blocks a Yahoo error-reporting fix from reaching readers.

This removes the provider-contract verification job from the release workflow and keeps the independent provider-contract workflow unchanged. Releases continue to require ecosystem qualification, the supported-platform compatibility matrix, source quality, strict documentation builds, dependency auditing, validated distributions, and checksums.

Verification: `uv run pytest tests/test_release_workflows.py tests/test_provider_contract_verification.py -q -ra` passes 16 tests, and `uv run pre-commit run --all-files` passes.